### PR TITLE
Dev (70 warnings)

### DIFF
--- a/SRC/analysis/integrator/Dynamic/Newmark.cpp
+++ b/SRC/analysis/integrator/Dynamic/Newmark.cpp
@@ -160,18 +160,18 @@ int Newmark::newStep(double deltaT)
     (*Utdotdot) = *Udotdot;
 
     if (unknown == Displacement || unknown == Velocity)  {    
-        // determine new velocities and accelerations at t+deltaT
-        double a1 = (1.0 - gamma/beta); 
-        double a2 = deltaT*(1.0 - 0.5*gamma/beta);
-        Udot->addVector(a1, *Utdotdot, a2);
+      // determine new velocities and accelerations at t+deltaT
+      double a1 = (1.0 - gamma/beta); 
+      double a2 = deltaT*(1.0 - 0.5*gamma/beta);
+      Udot->addVector(a1, *Utdotdot, a2);
 
-        double a3 = -1.0/(beta*deltaT);
-        double a4 = 1.0 - 0.5/beta;
-        Udotdot->addVector(a4, *Utdot, a3);
+      double a3 = -1.0/(beta*deltaT);
+      double a4 = 1.0 - 0.5/beta;
+      Udotdot->addVector(a4, *Utdot, a3);
 
-        // set the trial response quantities
-        theModel->setVel(*Udot);
-        theModel->setAccel(*Udotdot);
+      // set the trial response quantities
+      theModel->setVel(*Udot);
+      theModel->setAccel(*Udotdot);
 
     } else {
       // determine new displacements and velocities at t+deltaT      

--- a/SRC/analysis/integrator/control/PredictorControl.h
+++ b/SRC/analysis/integrator/control/PredictorControl.h
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+//                                   xara
+//                              https://xara.so
+//
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2025, OpenSees/Xara Developers
+// All rights reserved.  No warranty, explicit or implicit, is provided.
+//
+// This source code is licensed under the BSD 2-Clause License.
+// See LICENSE file or https://opensource.org/licenses/BSD-2-Clause
+//
+//===----------------------------------------------------------------------===//
+//
+
+#include <cmath>
+
+class PredictorControl {
+    public:
+    PredictorControl( double base_step,
+                      int target_count,
+                      double min_size,
+                      double max_size,
+                      double exponent)
+    // : base_step(base_step)
+    : target_count(target_count)
+    , min_size(min_size)
+    , max_size(max_size)
+    , exponent(exponent)
+    , last_step(base_step)
+    , next_step(base_step)
+    , current_count(0)
+    {
+
+    }
+    
+    void reset(double step_size) {
+        current_count = 0;
+        last_step = step_size;
+        next_step = step_size;
+    }
+
+    int update() {
+        current_count++;
+        return current_count;
+    }
+
+    double size() const {
+        double factor = std::pow(target_count / current_count, exponent);
+        double step = last_step * factor;
+
+        if (step < min_size)
+            step = min_size;
+        else if (step > max_size)
+            step = max_size;
+        return step;
+    }
+
+    
+    double last_step;
+    double next_step;
+    double current_count;
+
+    private:
+    double target_count;
+    double min_size;
+    double max_size;
+    double exponent;
+    // double base_step;
+    //
+};

--- a/SRC/coordTransformation/Frame/BasicFrameTransf.tpp
+++ b/SRC/coordTransformation/Frame/BasicFrameTransf.tpp
@@ -127,7 +127,7 @@ template<int ndf>
 const Vector &
 BasicFrameTransf3d<ndf>::getBasicTrialDisp()
 {
-  static VectorND<6> ub;
+  static VectorND<6> ub{};
   static Vector wrapper(ub);
   Vector3D wi = t.getNodeRotationLogarithm(0),
            wj = t.getNodeRotationLogarithm(1);
@@ -162,7 +162,7 @@ template<int ndf>
 const Vector &
 BasicFrameTransf3d<ndf>::getBasicTrialVel()
 {
-  static VectorND<6> ub;
+  static VectorND<6> ub{};
   static Vector wrapper(ub);
   opserr << "Unimplemented method\n";
   return wrapper;

--- a/SRC/coordTransformation/Frame/EuclidFrameTransf.tpp
+++ b/SRC/coordTransformation/Frame/EuclidFrameTransf.tpp
@@ -247,7 +247,7 @@ EuclidFrameTransf<nn,ndf,IsoT>::getStateVariation()
 
   const Matrix3D R = basis.getRotation();
 
-  // (1) Global Offsets
+  // -) Global Offsets
   // Do ui -= ri x wi
   if constexpr (ndf >= 6)
     if (offsets && !(offset_flags&OffsetLocal)) [[unlikely]] {
@@ -261,15 +261,15 @@ EuclidFrameTransf<nn,ndf,IsoT>::getStateVariation()
       }
     }
 
-  // (2) Rotations and translations
-
+  // 2) Isometry
+  // 2.1) Rotation
   for (int i=0; i<nn; i++) {
     const int j = i * ndf;
     ul.insert(j  , R^Vector3D{ul[j+0], ul[j+1], ul[j+2]}, 1.0);
     ul.insert(j+3, R^Vector3D{ul[j+3], ul[j+4], ul[j+5]}, 1.0);
   }
 
-  // Projection
+  // 2.2) Projection
   {
     const Vector3D wr = basis.getRotationVariation(ndf, &ul[0]);
     const Vector3D dc = basis.getPositionVariation(ndf, &ul[0]);
@@ -282,7 +282,7 @@ EuclidFrameTransf<nn,ndf,IsoT>::getStateVariation()
     }
   }
 
-  // 3) Offsets
+  // -) Offsets
   if constexpr (ndf >= 6)
     if (offsets && (offset_flags&OffsetLocal)) [[unlikely]] {
       const std::array<Vector3D, nn>& offset = *offsets;
@@ -295,7 +295,7 @@ EuclidFrameTransf<nn,ndf,IsoT>::getStateVariation()
       }
     }
 
-  // (5) Logarithm of rotations
+  // 3) Element parameters
   if (1) { // !(offset_flags & LogIter)) {
     for (int i=0; i<nn; i++) {
       const int j = i * ndf+3;
@@ -316,9 +316,10 @@ int
 EuclidFrameTransf<nn,ndf,IsoT>::push(VectorND<nn*ndf>&p, Operation op)
 {
   VectorND<nn*ndf>& pa = p;
+
   if (op != Operation::Rotation) {
 
-    // 1) Logarithm
+    // 3) Element Parameters
     if (1) { // !(offset_flags & LogIter)) {
       for (int i=0; i<nn; i++) {
         Vector3D m {pa[i*ndf + 3], pa[i*ndf + 4], pa[i*ndf + 5]};
@@ -326,7 +327,8 @@ EuclidFrameTransf<nn,ndf,IsoT>::push(VectorND<nn*ndf>&p, Operation op)
       }
     }
 
-    // 2.1) Sum of moments: m = sum_i mi + sum_i (xi x ni)
+    // 2.1) Isometry
+    // a) Sum of moments: m = sum_i mi + sum_i (xi x ni)
     Vector3D m{};
     for (int i=0; i<nn; i++) {
       // m += mi
@@ -335,7 +337,7 @@ EuclidFrameTransf<nn,ndf,IsoT>::push(VectorND<nn*ndf>&p, Operation op)
       // m += xi x ni
       m += this->getNodeLocation(i).cross(Vector3D{pa[i*ndf+0], pa[i*ndf+1], pa[i*ndf+2]});
     }
-    // 2.2) Adjust
+    // b) Adjust
     for (int i=0; i<nn; i++)
       pa.template assemble<6>(i*ndf, basis.getRotationGradient(i)^m, -1.0);
   }
@@ -343,7 +345,7 @@ EuclidFrameTransf<nn,ndf,IsoT>::push(VectorND<nn*ndf>&p, Operation op)
   if (op == Operation::Isometry)
     return 0;
 
-  // 3,4) Rotate and joint offsets
+  // 2.2) Rotation
   // pa = this->FrameTransform<nn,ndf>::pushConstant(pa);
   Matrix3D R = basis.getRotation();
   for (int i=0; i<nn; i++) {
@@ -352,7 +354,7 @@ EuclidFrameTransf<nn,ndf,IsoT>::push(VectorND<nn*ndf>&p, Operation op)
     pa.insert(base+3, R*Vector3D{pa[base+3], pa[base+4], pa[base+5]}, 1.0);
   }
 
-  // Offset
+  // -) Offset
   if (offsets != nullptr) [[unlikely]] {
     if (!(offset_flags&OffsetLocal))  {
       for (int i=0; i<nn; i++) {
@@ -382,7 +384,7 @@ EuclidFrameTransf<nn,ndf,IsoT>::push(MatrixND<nn*ndf,nn*ndf>&kb,
   VectorND<nn*ndf> p = pb;
 
   MatrixND<nn*ndf,nn*ndf> Kb = kb;
-
+  // 1) Element parameters
   if (op != Operation::Rotation) {// && (op != Operation::Bubnov)) {//!(offset_flags & LogIter)) {
     for (int i=0; i<nn; i++) {
       Vector3D m{pb[i*ndf+3], pb[i*ndf+4], pb[i*ndf+5]};
@@ -417,9 +419,11 @@ EuclidFrameTransf<nn,ndf,IsoT>::push(MatrixND<nn*ndf,nn*ndf>&kb,
       }
     }
   }
-
+  //
+  // 2) Isometry
+  //
+  // 2.2) Projection
   // Kl = A ^ k * A
-
   MatrixND<nn*ndf,nn*ndf>& Kl = kb;
   const MatrixND<nn*ndf,nn*ndf> A = getProjection();
   if (op == Operation::Bubnov)
@@ -469,6 +473,9 @@ EuclidFrameTransf<nn,ndf,IsoT>::push(MatrixND<nn*ndf,nn*ndf>&kb,
   if (op != Operation::Bubnov)
     Kl.addMatrixTransposeProduct(1.0, Kb, A,  -1.0);
 
+  //
+  // 2.1) Rotation
+  //
   // Kl = diag(R) * Kl * diag(R)^T
   FrameTransform<nn,ndf>::pushRotation(Kl, basis.getRotation());
   return 0;

--- a/SRC/coordTransformation/Frame/Isometry/CrisfieldIsometry.h
+++ b/SRC/coordTransformation/Frame/Isometry/CrisfieldIsometry.h
@@ -196,7 +196,7 @@ public:
   MatrixND<12,12>
   getRotationJacobian(const VectorND<12>&pl) final {
     MatrixND<12,12> dG{};
-
+    // TODO
     return dG;
   }
 

--- a/SRC/coordTransformation/LinearCrdTransf2d.cpp
+++ b/SRC/coordTransformation/LinearCrdTransf2d.cpp
@@ -1179,7 +1179,8 @@ LinearCrdTransf2d::Print(OPS_Stream &s, int flag)
   }
 
   if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-    s << "\t\t\t{\"name\": \"" << this->getTag()
+    s << OPS_PRINT_JSON_MATE_INDENT << "{";
+    s << "\"name\": \"" << this->getTag()
       << "\", \"type\": \"LinearCrdTransf2d\"";
     if (nodeIOffset != 0)
       s << ", \"iOffset\": [" << nodeIOffset[0] << ", " << nodeIOffset[1]

--- a/SRC/element/Frame/Elastic/CMakeLists.txt
+++ b/SRC/element/Frame/Elastic/CMakeLists.txt
@@ -4,7 +4,6 @@
 #                Pacific Earthquake Engineering Research Center
 #
 #==============================================================================
-target_sources(OPS_Runtime PRIVATE commands.cpp)
 
 target_sources(OPS_Element
     PRIVATE

--- a/SRC/element/Frame/EulerDeltaFrame3d.h
+++ b/SRC/element/Frame/EulerDeltaFrame3d.h
@@ -68,12 +68,13 @@ class EulerDeltaFrame3d : public FiniteElement<2, 3, 6>
     int updateParameter(int parameterID, Information &);
     int activateParameter(int parameterID);
 
-    virtual int getIntegral(Field field, State state, double& total);
 
   protected:
     int setNodes();
     
   private:
+    int getIntegral(Field field, State state, double& total);
+
     constexpr static int
       nen = 2,
       ndf = 6,

--- a/SRC/element/Frame/EulerFrame3d.h
+++ b/SRC/element/Frame/EulerFrame3d.h
@@ -83,7 +83,6 @@ class EulerFrame3d : public BasicFrame3d,
     virtual int            commitSensitivity(int gradNumber, int numGrads);
 
 
-    virtual int getIntegral(Field field, State state, double& total);
 
 
 protected:
@@ -103,6 +102,7 @@ private:
         maxNumSections = 20;
   constexpr static int max_nip = 20;
 
+  int getIntegral(Field field, State state, double& total);
   OpenSees::VectorND<6>&   getBasicForce();
   OpenSees::MatrixND<6,6>& stateDetermination(State state, int rate);
 

--- a/SRC/element/Frame/ForceFrame3d.h
+++ b/SRC/element/Frame/ForceFrame3d.h
@@ -105,7 +105,6 @@ public:
   int commitSensitivity(int gradNumber, int numGrads) final;
   int getResponseSensitivity(int responseID, int gradNumber, Information &) final;
 
-  virtual int getIntegral(Field field, State state, double& total);
 
   // MovableObject
   int sendSelf(int cTag, Channel &) override;
@@ -119,6 +118,8 @@ public:
   //
   // Constexpr
   //
+
+  int getIntegral(Field field, State state, double& total);
 
   constexpr static int NNW = 6; // number of non-warping basic DOFs
 

--- a/SRC/element/Frame/Prism.h
+++ b/SRC/element/Frame/Prism.h
@@ -1,0 +1,114 @@
+#pragma once
+#include <optional>
+#include <FrameSection.h>
+
+namespace OpenSees {
+namespace Frame {
+// TODO: Maybe make this public under ElasticFrameSection
+struct Prism {
+  // n-n
+  std::optional<double> A;
+  std::optional<double> Ay, Az;
+  // m-m
+  std::optional<double> Iy, Iz, Iyz;
+  // w-w
+  std::optional<double> Cw, Ca;
+  // n-m
+  std::optional<double> Qy, Qz;
+  // n-w
+  std::optional<double> Rw, Ry, Rz;
+  // m-w
+  std::optional<double> Sa, Sy, Sz;
+  // Derived
+  std::optional<double> J;    // Torsional constant
+
+
+  std::optional<double> E, G;
+
+
+  double thermal_coeff = 0.0,          // Thermal
+          thermal_depth = 0.0;
+
+  Prism() = default;
+  Prism(FrameSection& section):
+    A{}, Ay{}, Az{},
+    Iy{}, Iz{}, Iyz{},
+    Cw{}, Ca{},
+    Qy{}, Qz{},
+    Rw{}, Ry{}, Rz{},
+    Sa{}, Sy{}, Sz{},
+    J{},
+    E{}, G{}
+  {
+
+    // 1) Get exact reference properties; not all sections provide these
+
+    double value;
+    if (section.getIntegral(Field::Unit,   State::Init, value) == 0)
+      A = value;
+    else
+      A = 1.0;
+
+    if (section.getIntegral(Field::UnitZZ, State::Init, value) == 0)
+      Iy = value;
+
+    if (section.getIntegral(Field::UnitYY, State::Init, value) == 0)
+      Iz = value;
+
+    // 2) Get Young and Shear Modulus and determine if shear is supported
+    // by the section. The shear areas we pull here may still be 
+    // uncondensed.
+    const ID& layout = section.getType();
+    const Matrix& Ks = section.getInitialTangent();
+    for (int i=0; i<layout.Size(); i++) {
+      if (layout(i) == FrameStress::N && A) {
+        E = Ks(i,i)/(*A);
+      }
+      else if (layout(i) == FrameStress::Vy && A) {
+        G = Ks(i,i)/(*A);
+        Ay = A;
+      }
+      else if (layout(i) == FrameStress::Vz && A) {
+        G = Ks(i,i)/(*A);
+        Az = A;
+      }
+    }
+    //
+    for (int i=0; i<layout.Size(); i++) {
+      if (layout(i) == FrameStress::My && !Iy && E) {
+        Iy = Ks(i,i)/(*E);
+      }
+      else if (layout(i) == FrameStress::Mz && !Iz && E) {
+        Iz = Ks(i,i)/(*E);
+      }
+    }
+    // In a 3D shear-free section, G wouldnt have been found yet
+    for (int i=0; i<layout.Size(); i++) {
+      if (layout(i) == FrameStress::T && Iy && Iz && !G) {
+        G = Ks(i,i)/(*Iy + *Iz);
+      }
+    }
+
+    // 3) Condense Warping
+    static constexpr FrameStressLayout scheme = {
+        FrameStress::N,
+        FrameStress::Vy,
+        FrameStress::Vz,
+        FrameStress::T,
+        FrameStress::My,
+        FrameStress::Mz,
+    };
+
+    MatrixND<6,6> Kc = section.getTangent<6,scheme>(State::Init);
+
+    if (G) {
+      J  = Kc(3,3)/(*G);
+      if (Ay)
+        Ay = Kc(1,1)/(*G);
+      if (Az)
+        Az = Kc(2,2)/(*G);
+    }
+  }
+};
+} // namespace Frame
+} // namespace OpenSees

--- a/SRC/element/Frame/PrismFrame2d.cpp
+++ b/SRC/element/Frame/PrismFrame2d.cpp
@@ -108,7 +108,6 @@ PrismFrame2d::PrismFrame2d(int tag, int Nd1, int Nd2,
 
 
   const Matrix &sectTangent = section.getInitialTangent();
-  opserr << "K = " << sectTangent;
   const ID &sectCode = section.getType();
   for (int i=0; i<sectCode.Size(); i++) {
     int code = sectCode(i);

--- a/SRC/element/Frame/PrismFrame2d.cpp
+++ b/SRC/element/Frame/PrismFrame2d.cpp
@@ -11,6 +11,7 @@
 //
 // Written: cc,cmp 05/2024
 //
+#include <Frame/Prism.h>
 #include <Vector.h>
 #include <VectorND.h>
 #include <Matrix.h>
@@ -30,8 +31,7 @@
 #include <ElementResponse.h>
 #include <math.h>
 
-using OpenSees::VectorND;
-using OpenSees::MatrixND;
+using namespace OpenSees;
 
 Matrix PrismFrame2d::K(6,6);
 Vector PrismFrame2d::P(6);
@@ -51,7 +51,6 @@ PrismFrame2d::PrismFrame2d()
   p0.zero();
   kg.zero();
 
-  // set node pointers to NULL
   for (int i=0; i<2; i++)
     theNodes[i] = nullptr;      
 }
@@ -65,6 +64,7 @@ PrismFrame2d::PrismFrame2d(int tag, double a, double e, double i,
    alpha(Alpha), depth(depth_), rho(r), 
    mass_flag(cm), release(rel), 
    geom_flag(geom_flag_),
+   shear_flag(0),
    Q(6), connectedExternalNodes(2), theCoordTransf(nullptr)
 {
   connectedExternalNodes(0) = Nd1;
@@ -91,22 +91,24 @@ PrismFrame2d::PrismFrame2d(int tag, int Nd1, int Nd2,
                            CrdTransf &coordTransf, 
                            double Alpha, double depth_, 
                            double r, int cm, bool use_mass, int rel,
-                           int geom_flag_)
+                           int geom_flag_, int shear_flag)
   : Element(tag,ELE_TAG_ElasticBeam2d), 
     G(0.0), Ay(0.0),
     alpha(Alpha), depth(depth_), 
     rho(r), mass_flag(cm), 
     release(rel),
     geom_flag(geom_flag_),
+    shear_flag(shear_flag),
     Q(6), connectedExternalNodes(2), theCoordTransf(nullptr)
 {
-
+#if 0
   section.getIntegral(Field::Unit,   State::Init, A);
   section.getIntegral(Field::UnitY,  State::Init, Ay);
   section.getIntegral(Field::UnitYY, State::Init, Iz);
 
 
   const Matrix &sectTangent = section.getInitialTangent();
+  opserr << "K = " << sectTangent;
   const ID &sectCode = section.getType();
   for (int i=0; i<sectCode.Size(); i++) {
     int code = sectCode(i);
@@ -123,6 +125,19 @@ PrismFrame2d::PrismFrame2d(int tag, int Nd1, int Nd2,
     }
   }
   
+#else
+  Frame::Prism prism_props(section);
+  A  = *prism_props.A;
+  Iz = *prism_props.Iz;
+  E  = *prism_props.E;
+  G  = *prism_props.G;
+  if (!shear_flag) {
+    Ay = 0.0;
+  } 
+  else {
+    Ay = *prism_props.Ay;
+  }
+#endif
   connectedExternalNodes(0) = Nd1;
   connectedExternalNodes(1) = Nd2;
   
@@ -357,13 +372,13 @@ PrismFrame2d::update()
 const Matrix &
 PrismFrame2d::getTangentStiff()
 {
-  return theCoordTransf->getGlobalStiffMatrix(ke, q);
+  return theCoordTransf->getGlobalStiffMatrix(Matrix(ke), q);
 }
 
 const Matrix &
 PrismFrame2d::getInitialStiff()
 {
-  return theCoordTransf->getInitialGlobalStiffMatrix(km);
+  return theCoordTransf->getInitialGlobalStiffMatrix(Matrix(km));
 }
 
 const Matrix &
@@ -411,7 +426,7 @@ PrismFrame2d::getMass()
       // add translational and rotational parts
       ml = mlTrn + mlRot;
       // transform from local to global system
-      return theCoordTransf->getGlobalMatrixFromLocal(M);
+      return theCoordTransf->getGlobalMatrixFromLocal(Matrix(M));
     }
 
     mass_initialized = true;

--- a/SRC/element/Frame/PrismFrame2d.h
+++ b/SRC/element/Frame/PrismFrame2d.h
@@ -38,7 +38,7 @@ class PrismFrame2d : public Element
                   double alpha, double depth,
                   double rho, int mass_flag, bool use_mass,
                   int release,
-                  int geom_flag);
+                  int geom_flag, int shear_flag);
 
     ~PrismFrame2d();
 
@@ -100,6 +100,7 @@ class PrismFrame2d : public Element
     int mass_flag;        // consistent mass flag
     int release;      // moment release 0=none, 1=I, 2=J, 3=I,J
     int geom_flag;
+    int shear_flag;
 
     // State variables; not passed in send/recvSelf
     double L;                    // Initial length

--- a/SRC/element/Truss/TrussSection.cpp
+++ b/SRC/element/Truss/TrussSection.cpp
@@ -20,8 +20,6 @@
 //
 // Description: This file contains the implementation for the TrussSection class.
 //
-// What: "@(#) TrussSection.C, revA"
-//
 // Written: fmk
 // Created: 07/98
 // Revision: A
@@ -41,7 +39,7 @@
 
 #include <math.h>
 
-// initialise the class wide variables
+// initialize the class wide variables
 Matrix TrussSection::trussM2(2, 2);
 Matrix TrussSection::trussM3(3, 3);
 Matrix TrussSection::trussM4(4, 4);
@@ -91,7 +89,7 @@ TrussSection::TrussSection(int tag, int dim, int Nd1, int Nd2,
 
   // set node pointers to NULL
   for (i = 0; i < 2; i++)
-    theNodes[i] = 0;
+    theNodes[i] = nullptr;
 
   cosX[0] = 0.0;
   cosX[1] = 0.0;
@@ -121,7 +119,7 @@ TrussSection::TrussSection()
 
   // set node pointers to NULL
   for (int i = 0; i < 2; i++)
-    theNodes[i] = 0;
+    theNodes[i] = nullptr;
 
   cosX[0] = 0.0;
   cosX[1] = 0.0;
@@ -390,7 +388,8 @@ TrussSection::revertToStart()
 int
 TrussSection::update()
 {
-  if (L == 0.0) { // - problem in setDomain() no further warnings
+  if (L == 0.0) {
+    // problem in setDomain, no further warnings
     return -1;
   }
 
@@ -414,7 +413,8 @@ TrussSection::update()
 const Matrix&
 TrussSection::getTangentStiff()
 {
-  if (L == 0.0) { // - problem in setDomain() no further warnings
+  if (L == 0.0) {
+    // problem in setDomain, no further warnings
     theMatrix->Zero();
     return *theMatrix;
   }
@@ -424,8 +424,7 @@ TrussSection::getTangentStiff()
 
   const Matrix& k = theSection->getSectionTangent();
   double AE       = 0.0;
-  int i;
-  for (i = 0; i < order; i++) {
+  for (int i = 0; i < order; i++) {
     if (code(i) == SECTION_RESPONSE_P)
       AE += k(i, i);
   }
@@ -436,7 +435,7 @@ TrussSection::getTangentStiff()
   int numDOF2 = numDOF / 2;
   double temp;
   AE /= L;
-  for (i = 0; i < dimension; i++) {
+  for (int i = 0; i < dimension; i++) {
     for (int j = 0; j < dimension; j++) {
       temp                            = cosX[i] * cosX[j] * AE;
       stiff(i, j)                     = temp;
@@ -582,7 +581,8 @@ TrussSection::addInertiaLoadToUnbalance(const Vector& accel)
 const Vector&
 TrussSection::getResistingForce()
 {
-  if (L == 0.0) { // - problem in setDomain() no further warnings
+  if (L == 0.0) {
+    // problem in setDomain, no further warnings
     theVector->Zero();
     return *theVector;
   }
@@ -807,6 +807,17 @@ TrussSection::recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& the
 void
 TrussSection::Print(OPS_Stream& s, int flag)
 {
+  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << OPS_PRINT_JSON_ELEM_INDENT << "{";
+    s << "\"name\": " << this->getTag() << ", ";
+    s << "\"type\": \"Truss\", ";
+    s << "\"nodes\": [" << connectedExternalNodes(0) << ", " 
+                        << connectedExternalNodes(1) << "], ";
+    s << "\"massperlength\": " << rho << ", ";
+    s << "\"section\": " << theSection->getTag() << "}";
+    return;
+  }
+
   // compute the strain and axial force in the member
   double strain, force;
   if (L == 0.0) {
@@ -865,15 +876,6 @@ TrussSection::Print(OPS_Stream& s, int flag)
     s << this->getTag() << "  " << strain << "  ";
     s << force << endln;
   }
-
-  if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-    s << "\t\t\t{";
-    s << "\"name\": " << this->getTag() << ", ";
-    s << "\"type\": \"TrussSection\", ";
-    s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << "], ";
-    s << "\"massperlength\": " << rho << ", ";
-    s << "\"section\": \"" << theSection->getTag() << "\"}";
-  }
 }
 
 double
@@ -909,11 +911,13 @@ TrussSection::setResponse(const char** argv, int argc, OPS_Stream& output)
   output.attr("node2", connectedExternalNodes[1]);
 
   //
-  // we compare argv[0] for known response types for the Truss
+  // compare argv[0] for known response types for the Truss
   //
 
-  if ((strcmp(argv[0], "force") == 0) || (strcmp(argv[0], "forces") == 0) ||
-      (strcmp(argv[0], "globalForce") == 0) || (strcmp(argv[0], "globalForces") == 0)) {
+  if ((strcmp(argv[0], "force") == 0) || 
+      (strcmp(argv[0], "forces") == 0) ||
+      (strcmp(argv[0], "globalForce") == 0) || 
+      (strcmp(argv[0], "globalForces") == 0)) {
     char outputData[32];
     int numDOFperNode = numDOF / 2;
     for (int i = 0; i < numDOFperNode; i++) {
@@ -990,7 +994,8 @@ TrussSection::getResponse(int responseID, Information& eleInfo)
   static Matrix kVec(1, 1);
 
   switch (responseID) {
-  case 1:  return eleInfo.setVector(this->getResistingForce());
+  case 1:
+    return eleInfo.setVector(this->getResistingForce());
 
   case 11: {
     Vector P(numDOF);
@@ -999,8 +1004,7 @@ TrussSection::getResponse(int responseID, Information& eleInfo)
 
     const Vector& s = theSection->getStressResultant();
     force           = 0.0;
-    int i;
-    for (i = 0; i < order; i++) {
+    for (int i = 0; i < order; i++) {
       if (code(i) == SECTION_RESPONSE_P)
         force += s(i);
     }
@@ -1020,8 +1024,7 @@ TrussSection::getResponse(int responseID, Information& eleInfo)
 
       const Vector& s = theSection->getStressResultant();
       force           = 0.0;
-      int i;
-      for (i = 0; i < order; i++) {
+      for (int i = 0; i < order; i++) {
         if (code(i) == SECTION_RESPONSE_P)
           force += s(i);
       }
@@ -1048,8 +1051,7 @@ TrussSection::getResponse(int responseID, Information& eleInfo)
 
       const Matrix& ks = theSection->getSectionTangent();
       force            = 0.0;
-      int i;
-      for (i = 0; i < order; i++) {
+      for (int i = 0; i < order; i++) {
         if (code(i) == SECTION_RESPONSE_P)
           force += ks(i, i);
       }
@@ -1172,7 +1174,7 @@ TrussSection::getResistingForceSensitivity(int gradIndex)
   theVector->Zero();
 
   // Initial declarations
-  int i;
+
   double stressSensitivity, temp1, temp2;
 
   // Make sure the material is up to date
@@ -1188,7 +1190,7 @@ TrussSection::getResistingForceSensitivity(int gradIndex)
 
   const Vector& dsdh = theSection->getStressResultantSensitivity(gradIndex, true);
   double dNdh        = 0.0;
-  for (i = 0; i < order; i++) {
+  for (int i = 0; i < order; i++) {
     if (code(i) == SECTION_RESPONSE_P)
       dNdh += dsdh(i);
   }
@@ -1256,14 +1258,14 @@ TrussSection::getResistingForceSensitivity(int gradIndex)
     const Vector& disp1      = theNodes[0]->getTrialDisp();
     const Vector& disp2      = theNodes[1]->getTrialDisp();
     double dLengthDerivative = 0.0;
-    for (i = 0; i < dimension; i++) {
+    for (int i = 0; i < dimension; i++) {
       dLengthDerivative += (disp2(i) - disp1(i)) * dcosXdh[i];
     }
 
     //double materialTangent = theMaterial->getTangent();
     const Matrix& ks = theSection->getSectionTangent();
     double EA        = 0.0;
-    for (i = 0; i < order; i++) {
+    for (int i = 0; i < order; i++) {
       if (code(i) == SECTION_RESPONSE_P)
         EA += ks(i, i);
     }
@@ -1290,7 +1292,7 @@ TrussSection::getResistingForceSensitivity(int gradIndex)
   // Compute sensitivity depending on 'parameter'
   double N        = 0.0;
   const Vector& s = theSection->getStressResultant();
-  for (i = 0; i < order; i++) {
+  for (int i = 0; i < order; i++) {
     if (code(i) == SECTION_RESPONSE_P)
       N += s(i);
   }
@@ -1301,7 +1303,7 @@ TrussSection::getResistingForceSensitivity(int gradIndex)
     // Cross-sectional area
 
   } else { // Density, material parameter or nodal coordinate
-    for (i = 0; i < dimension; i++) {
+    for (int i = 0; i < dimension; i++) {
       temp                      = dNdh * cosX[i] + N * dcosXdh[i];
       (*theVector)(i)           = -temp;
       (*theVector)(i + numDOF2) = temp;
@@ -1309,7 +1311,7 @@ TrussSection::getResistingForceSensitivity(int gradIndex)
   }
 
   // subtract external load sensitivity
-  if (theLoadSens == 0) {
+  if (theLoadSens == nullptr) {
     theLoadSens = new Vector(numDOF);
   }
   (*theVector) -= *theLoadSens;
@@ -1317,11 +1319,11 @@ TrussSection::getResistingForceSensitivity(int gradIndex)
   return *theVector;
 }
 
+
 int
 TrussSection::commitSensitivity(int gradIndex, int numGrads)
 {
   // Initial declarations
-  int i;
   double strainSensitivity, temp1, temp2;
 
   // Displacement difference between the two ends
@@ -1401,22 +1403,22 @@ TrussSection::commitSensitivity(int gradIndex, int numGrads)
     const Vector& disp1      = theNodes[0]->getTrialDisp();
     const Vector& disp2      = theNodes[1]->getTrialDisp();
     double dLengthDerivative = 0.0;
-    for (i = 0; i < dimension; i++) {
+    for (int i = 0; i < dimension; i++) {
       dLengthDerivative += (disp2(i) - disp1(i)) * dcosXdh[i];
     }
 
     strainSensitivity += dLengthDerivative / L;
 
-    if (nodeParameterID0 == 1) { // here x1 is random
+    if (nodeParameterID0 == 1) { // here x1 is varying
       strainSensitivity += dLength / (L * L * L) * dx;
     }
-    if (nodeParameterID0 == 2) { // here y1 is random
+    if (nodeParameterID0 == 2) { // here y1 is varying
       strainSensitivity += dLength / (L * L * L) * dy;
     }
-    if (nodeParameterID1 == 1) { // here x2 is random
+    if (nodeParameterID1 == 1) { // here x2 is varying
       strainSensitivity -= dLength / (L * L * L) * dx;
     }
-    if (nodeParameterID1 == 2) { // here y2 is random
+    if (nodeParameterID1 == 2) { // here y2 is varying
       strainSensitivity -= dLength / (L * L * L) * dy;
     }
   }
@@ -1458,15 +1460,10 @@ TrussSection::addInertiaLoadSensitivityToUnbalance(const Vector& accel,
 
     int nodalDOF = numDOF / 2;
 
-#ifdef _G3DEBUG
-    if (nodalDOF != Raccel1.Size() || nodalDOF != Raccel2.Size()) {
-      opserr << "Truss::addInertiaLoadToUnbalance " << "matrix and vector sizes are incompatible\n";
-      return -1;
-    }
-#endif
+    assert((nodalDOF == Raccel1.Size()) && (nodalDOF == Raccel2.Size()));
 
     double M = 0.5 * rho * L;
-    // want to add ( - fact * M R * accel ) to unbalance
+    // Add ( - fact * M R * accel ) to unbalance
     for (int i = 0; i < dimension; i++) {
       double val1 = Raccel1(i);
       double val2 = Raccel2(i);
@@ -1478,7 +1475,8 @@ TrussSection::addInertiaLoadSensitivityToUnbalance(const Vector& accel,
       (*theLoadSens)(i)            = val1;
       (*theLoadSens)(i + nodalDOF) = val2;
     }
-  } else {
+  }
+  else {
 
     // check for a quick return
     if (L == 0.0 || rho == 0.0)
@@ -1518,5 +1516,3 @@ TrussSection::addInertiaLoadSensitivityToUnbalance(const Vector& accel,
   }
   return 0;
 }
-
-// AddingSensitivity:END /////////////////////////////////////////////

--- a/SRC/element/Truss/TrussSection.h
+++ b/SRC/element/Truss/TrussSection.h
@@ -18,24 +18,17 @@
 **                                                                    **
 ** ****************************************************************** */
 
-// $Revision$
-// $Date$
-// $URL$
-
-
-#ifndef TrussSection_h
-#define TrussSection_h
-
 // Written: fmk
 // Created: 07/98
 // Revision: A
 //
 // Description: This file contains the class definition for Truss. A Truss
 // object provides the abstraction of the small deformation bar element.
-// Each truss object is associated with a section object. This Truss element
-// will work in 1d, 2d or 3d problems.
+// Each truss object is associated with a section object. 
+// This Truss element will work in 1d, 2d or 3d problems.
 //
-// What: "@(#) Truss.h, revA"
+#ifndef TrussSection_h
+#define TrussSection_h
 
 #include <Element.h>
 #include <Matrix.h>
@@ -45,69 +38,76 @@ class Node;
 class Channel;
 class FrameSection;
 
+
 class TrussSection : public Element {
 public:
-  TrussSection(int tag, int dimension, int Nd1, int Nd2, FrameSection& theSection,
-               double rho = 0.0, int doRayleighDamping = 0, int cMass = 0);
+  TrussSection(int tag, 
+               int dimension, 
+               int Nd1, int Nd2, 
+               FrameSection& theSection,
+               double rho = 0.0, 
+               int doRayleighDamping = 0, 
+               int cMass = 0);
 
   TrussSection();
   ~TrussSection();
 
   const char*
-  getClassType(void) const
+  getClassType() const override
   {
     return "TrussSection";
-  };
+  }
 
   // public methods to obtain information about dof & connectivity
-  int getNumExternalNodes(void) const;
-  const ID& getExternalNodes(void);
-  Node** getNodePtrs(void);
+  int getNumExternalNodes() const override;
+  const ID& getExternalNodes() override;
+  Node** getNodePtrs() override;
 
-  int getNumDOF(void);
-  void setDomain(Domain* theDomain);
+  int getNumDOF() override;
+  void setDomain(Domain*);
 
-  // public methods to set the state of the element
-  int commitState(void);
-  int revertToLastCommit(void);
-  int revertToStart(void);
-  int update(void);
+  // Alter the state of the element
+  int commitState() override;
+  int revertToLastCommit() override;
+  int revertToStart() override;
+  int update() override;
 
-  // public methods to obtain stiffness, mass, damping and residual information
-  const Matrix& getTangentStiff(void);
-  const Matrix& getInitialStiff(void);
-  const Matrix& getDamp(void);
-  const Matrix& getMass(void);
+  // Obtain stiffness, mass, damping and residual information
+  const Matrix& getTangentStiff() override;
+  const Matrix& getInitialStiff() override;
+  const Matrix& getDamp() override;
+  const Matrix& getMass() override;
+  const Vector& getResistingForce() override;
+  const Vector& getResistingForceIncInertia() override;
 
-  void zeroLoad(void);
-  int addLoad(ElementalLoad* theLoad, double loadFactor);
-  int addInertiaLoadToUnbalance(const Vector& accel);
+  void zeroLoad() override;
+  int addLoad(ElementalLoad* theLoad, double loadFactor) override;
+  int addInertiaLoadToUnbalance(const Vector& accel) override;
 
-  const Vector& getResistingForce(void);
-  const Vector& getResistingForceIncInertia(void);
+  // MovableObject interface
+  int sendSelf(int commitTag, Channel&) override;
+  int recvSelf(int commitTag, Channel&, FEM_ObjectBroker&) override;
 
-  // public methods for element output
-  int sendSelf(int commitTag, Channel& theChannel);
-  int recvSelf(int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker);
-  void Print(OPS_Stream& s, int flag) final;
+  // TaggedObject interface
+  void Print(OPS_Stream& s, int flag) override;
 
   Response* setResponse(const char** argv, int argc, OPS_Stream& s);
-  int getResponse(int responseID, Information& eleInformation);
+  int getResponse(int responseID, Information& );
 
-  // AddingSensitivity:BEGIN //////////////////////////////////////////
+  // Sensitivity
   int addInertiaLoadSensitivityToUnbalance(const Vector& accel, bool tag);
-  int setParameter(const char** argv, int argc, Parameter& param);
+  int setParameter(const char** argv, int argc, Parameter&);
   int updateParameter(int parameterID, Information& info);
   int activateParameter(int parameterID);
   const Vector& getResistingForceSensitivity(int gradNumber);
   const Matrix& getKiSensitivity(int gradNumber);
   const Matrix& getMassSensitivity(int gradNumber);
   int commitSensitivity(int gradNumber, int numGrads);
-  // AddingSensitivity:END ///////////////////////////////////////////
 
-protected:
+
 private:
   double computeCurrentStrain() const;
+
   // Layout of stress resultants
   static constexpr FrameStressLayout section_layout = {
     FrameStress::N,
@@ -119,8 +119,8 @@ private:
   int numDOF;                // number of dof for truss
 
   Vector* theLoad;   // pointer to the load vector P
-  Matrix* theMatrix; // pointer to objects matrix (a class wide Matrix)
-  Vector* theVector; // pointer to objects vector (a class wide Vector)
+  Matrix* theMatrix; // pointer to objects matrix (a static Matrix)
+  Vector* theVector; // pointer to objects vector (a static Vector)
 
   double cosX[3]; // direction cosines
 
@@ -129,15 +129,14 @@ private:
   int doRayleighDamping; // flag to include Rayleigh damping
   int cMass;             // consistent mass flag
 
-  Node* theNodes[2];
+  Node*   theNodes[2];
   double* initialDisp;
 
   FrameSection* theSection;
 
-  // AddingSensitivity:BEGIN //////////////////////////////////////////
+  // Sensitivity
   int parameterID;
   Vector* theLoadSens;
-  // AddingSensitivity:END ///////////////////////////////////////////
 
   // static data - single copy for all objects of the class
   static Matrix trussM2;  // class wide matrix for 2*2

--- a/SRC/material/Frame/ElasticLinearFrameSection3d.cpp
+++ b/SRC/material/Frame/ElasticLinearFrameSection3d.cpp
@@ -260,8 +260,7 @@ ElasticLinearFrameSection3d::~ElasticLinearFrameSection3d()
 FrameSection*
 ElasticLinearFrameSection3d::getFrameCopy(const FrameStressLayout& layout)
 {
-  // TODO: 
-  // - take layout as argument
+  // TODO:
   // - overload 
   //   template<int n> ID::operator==(std::array<int, n>)
   //

--- a/SRC/material/Frame/ElasticLinearFrameSection3d.h
+++ b/SRC/material/Frame/ElasticLinearFrameSection3d.h
@@ -50,20 +50,20 @@ public:
     return "ElasticFrameSection3d";
   }
   
-  int commitState() override;
-  int revertToLastCommit() override;
-  int revertToStart() override;
+  int commitState() final;
+  int revertToLastCommit() final;
+  int revertToStart() final;
   
-  int setTrialSectionDeformation(const Vector&) override;
+  int setTrialSectionDeformation(const Vector&) final;
   const Vector &getSectionDeformation();
   
   int getIntegral(Field field, State state, double&) const final;
 
-  const Vector &getStressResultant() override;
-  const Matrix &getSectionTangent() override;
-  const Matrix &getInitialTangent() override;
-  const Matrix &getSectionFlexibility() override;
-  const Matrix &getInitialFlexibility() override;
+  const Vector &getStressResultant() final;
+  const Matrix &getSectionTangent() final;
+  const Matrix &getInitialTangent() final;
+  const Matrix &getSectionFlexibility() final;
+  const Matrix &getInitialFlexibility() final;
   
   FrameSection *getFrameCopy() final;
   FrameSection* getFrameCopy(const FrameStressLayout&) final;
@@ -75,8 +75,8 @@ public:
   
   void Print(OPS_Stream &s, int flag) final;
 
-  int setParameter(const char **argv, int argc, Parameter &);
-  int updateParameter(int parameterID, Information &info);
+  int setParameter(const char **argv, int argc, Parameter &) final;
+  int updateParameter(int parameterID, Information &info) final;
   int activateParameter(int parameterID);
   const Vector& getStressResultantSensitivity(int gradIndex,
                                               bool conditional);
@@ -106,20 +106,6 @@ public:
 
   static ID layout;
   std::array<double, 2> centroid;
-
-
-//   struct Tangent {
-//      OpenSees::MatrixND<3,3> nn,         nw, nv, 
-//                                  mn, mm, mw, mv, 
-//                                          ww,
-//                                              vv;
-//      void zero() {
-//             nn.zero();            nw.zero(); nv.zero();
-//             mn.zero(); mm.zero(); mw.zero(); mv.zero();
-//                                   ww.zero();
-//                                              vv.zero();
-//      }
-//   } K_pres;
 };
 
 } // namespace OpenSees

--- a/SRC/material/Yield/plasticHardeningMaterial/MultiLinearKp.cpp
+++ b/SRC/material/Yield/plasticHardeningMaterial/MultiLinearKp.cpp
@@ -8,7 +8,7 @@
 #include <Logging.h>
 
 #define MAT_TAG_MULTILINEAR -1
-#define DEBG 0
+
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
@@ -86,12 +86,11 @@ double sumDisp = val_trial;
 		}
 	}
 
-	if(sFactor != 1.0)
+	if (sFactor != 1.0)
 		K = Kp(0)*sFactor;
 	else
 		K = residual*K;
 
-	// opserr << "K = " << K << ", sFactor = " << sFactor << endln; // opserr << "\a";
 	return K;
 }
 
@@ -101,9 +100,10 @@ MultiLinearKp::Print(OPS_Stream &s, int flag)
 {
     this->PlasticHardeningMaterial::Print(s, flag);
 
-    if (flag == OPS_PRINT_PRINTMODEL_JSON) {  
-      s << "{}";
-    } else {
+    if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+      s << OPS_PRINT_JSON_MATE_INDENT << "{}";
+    } 
+	else {
       s << "+-MultiLinear" << "\n";
       s << "    Kp = " << this->getTrialPlasticStiffness();
       s << "    SumPlasDefo Vector = " <<  sumPlasDefo;
@@ -112,7 +112,7 @@ MultiLinearKp::Print(OPS_Stream &s, int flag)
 }
 
 PlasticHardeningMaterial *
-MultiLinearKp::getCopy(void)
+MultiLinearKp::getCopy()
 {
     Vector spd(numPoints);
     Vector kp(numPoints);

--- a/SRC/material/nD/DruckerPragerThermal.cpp
+++ b/SRC/material/nD/DruckerPragerThermal.cpp
@@ -949,7 +949,8 @@ void DruckerPragerThermal::plastic_integrator()
 	return;
 }
 
-int DruckerPragerThermal::updateElasticParam()
+int 
+DruckerPragerThermal::updateElasticParam()
 {
 	double Sigma_mean = 0.0;
 	if (mElastFlag == 1 && mFlag == 1) {
@@ -959,7 +960,6 @@ int DruckerPragerThermal::updateElasticParam()
 		mG = mGref * pow(1 + (Sigma_mean / mPatm), 0.5);
 		mCe = mK * mIIvol + 2 * mG*mIIdev;
 		mFlag = 0;
-		//opserr << "Plastic Integrator -->" << "K = " << mK  << "  G =" << mG << endln;
 	}
 	else if (mElastFlag != 1) {
 		mFlag = 1;

--- a/SRC/material/nD/UWmaterials/DruckerPrager.cpp
+++ b/SRC/material/nD/UWmaterials/DruckerPrager.cpp
@@ -624,18 +624,18 @@ DruckerPrager::plastic_integrator( )
 	return;
 }
 
-int DruckerPrager::updateElasticParam( )
+int 
+DruckerPrager::updateElasticParam( )
 {
     double Sigma_mean = 0.0;
-	if ( mElastFlag == 1 && mFlag == 1){
+	if ( mElastFlag == 1 && mFlag == 1) {
 		Sigma_mean = -one3*(mSigma(0)+mSigma(1)+mSigma(2));
         if (Sigma_mean < 0.0) Sigma_mean = 0.0;  // prevents modulus update for cases where tension exists 
         mK = mKref * pow(1+(Sigma_mean/mPatm), 0.5);
         mG = mGref * pow(1+(Sigma_mean/mPatm), 0.5);
    		mCe  = mK * mIIvol + 2*mG*mIIdev;
         mFlag = 0;
-		//opserr << "Plastic Integrator -->" << "K = " << mK  << "  G =" << mG << endln;
-	} else if ( mElastFlag != 1 ){
+	} else if ( mElastFlag != 1 ) {
         mFlag = 1;
 	}
 

--- a/SRC/material/section/FiberSection2d.cpp
+++ b/SRC/material/section/FiberSection2d.cpp
@@ -47,14 +47,17 @@ ID FiberSection2d::code(2);
 // allocate memory for fibers
 FiberSection2d::FiberSection2d(int tag, int num, bool compCentroid): 
   FrameSection(tag, SEC_TAG_FiberSection2d),
-  numFibers(0), sizeFibers(num), theMaterials(0), matData(new double [num*2]{}),
+  numFibers(0), sizeFibers(num), theMaterials(0), 
+#ifdef SHARE_FIBERS
+  matData(new double [sizeFibers*2]{}),
+#else
+  matData(nullptr),
+#endif
   QzBar(0.0), ABar(0.0), yBar(0.0), computeCentroid(compCentroid),
   e(2), s(0), ks(0), dedh(2)
 {
     if (sizeFibers > 0) {
       theMaterials = new UniaxialMaterial *[sizeFibers]{};
-//    matData      = new double [sizeFibers*2]{};
-//    matData = std::make_shared<double[]>(new double [numFibers*2]{});
       // matData.reset();
     }
 
@@ -105,28 +108,34 @@ FiberSection2d::addFiber(UniaxialMaterial &theMat, const double Area, const doub
         newsize = 30;
       UniaxialMaterial **newArray = new UniaxialMaterial *[newsize]; 
       // std::shared_ptr<double[]> newMatData = std::make_shared<double[]>(new double [2 * newsize]);
+#ifdef SHARE_FIBERS
       std::shared_ptr<double[]> newMatData(new double [2 * newsize]);
+#else
+      double* newMatData = new double [2 * newsize];
+#endif
 
       // copy the old pointers and data
       for (int i = 0; i < sizeFibers; i++) {
-	  newArray[i]       = theMaterials[i];
-	  newMatData[2*i]   = matData[2*i];
-	  newMatData[2*i+1] = matData[2*i+1];
+        newArray[i]       = theMaterials[i];
+        newMatData[2*i]   = matData[2*i];
+        newMatData[2*i+1] = matData[2*i+1];
       }
 
       // initialize new memory
       for(int i = sizeFibers; i<newsize; i++) {
-	  newArray[i]       = nullptr;
-	  newMatData[2*i]   = 0.0;
-	  newMatData[2*i+1] = 0.0;
+        newArray[i]       = nullptr;
+        newMatData[2*i]   = 0.0;
+        newMatData[2*i+1] = 0.0;
       }
 
       sizeFibers = newsize;
 
       // set new memory
       if (theMaterials != nullptr) {
-	  delete [] theMaterials;
-	  // delete [] matData;
+        delete [] theMaterials;
+#ifndef SHARE_FIBERS
+        delete [] matData;
+#endif
       }
 
       theMaterials = newArray;
@@ -138,7 +147,7 @@ FiberSection2d::addFiber(UniaxialMaterial &theMat, const double Area, const doub
   matData[numFibers*2+1] = Area;
   theMaterials[numFibers] = theMat.getCopy();
 
-  if(theMaterials[numFibers] == 0) {
+  if (theMaterials[numFibers] == 0) {
     opserr <<"FiberSection2d::addFiber -- failed to get copy of a Material\n";
     return -1;
   }
@@ -183,7 +192,7 @@ FiberSection2d::getIntegral(Field field, State state, double& value) const
   switch (field) {
     case Field::Unit:
       for (int i=0; i<numFibers; i++) {
-        const double A  = matData[2*i+2];
+        const double A  = matData[2*i+1];
         value += A;
       }
       return 0;
@@ -195,7 +204,7 @@ FiberSection2d::getIntegral(Field field, State state, double& value) const
 
       for (int i=0; i<numFibers; i++) {
         double density;
-        const double A  = matData[2*i+2];
+        const double A  = matData[2*i+1];
         if (theMaterials[i]->getRho() != 0)
           value += A*density;
         else
@@ -207,7 +216,7 @@ FiberSection2d::getIntegral(Field field, State state, double& value) const
     case Field::UnitYY:
     case Field::UnitCentroidYY:
       for (int i=0; i<numFibers; i++) {
-        const double A  = matData[2*i+2];
+        const double A  = matData[2*i+1];
         const double y  = matData[2*i]
                         - yBar*(Field::UnitCentroidYY == field);
         value += A*y*y;
@@ -316,15 +325,21 @@ FiberSection2d::getFrameCopy(void)
 
   if (numFibers != 0) {
     theCopy->theMaterials = new UniaxialMaterial *[numFibers]; 
-    theCopy->matData = matData; // new double [numFibers*2];
+#ifdef SHARE_FIBERS
+    theCopy->matData = matData;
+#else 
+    theCopy->matData = new double [numFibers*2];
+#endif 
 
     for (int i = 0; i < numFibers; i++) {
-//    theCopy->matData[i*2] = matData[i*2];
-//    theCopy->matData[i*2+1] = matData[i*2+1];
+#ifndef SHARE_FIBERS
+      theCopy->matData[i*2] = matData[i*2];
+      theCopy->matData[i*2+1] = matData[i*2+1];
+#endif
       theCopy->theMaterials[i] = theMaterials[i]->getCopy();
 
       if (theCopy->theMaterials[i] == 0) {
-	opserr <<"FiberSection2d::getFrameCopy -- failed to get copy of a Material";
+        opserr <<"FiberSection2d::getFrameCopy -- failed to get copy of a Material";
         delete theCopy;
         return nullptr;
       }
@@ -512,7 +527,7 @@ FiberSection2d::sendSelf(int commitTag, Channel &theChannel)
 
 int
 FiberSection2d::recvSelf(int commitTag, Channel &theChannel,
-			 FEM_ObjectBroker &theBroker)
+                         FEM_ObjectBroker &theBroker)
 {
   int res = 0;
 
@@ -538,27 +553,32 @@ FiberSection2d::recvSelf(int commitTag, Channel &theChannel,
     // if current arrays not of correct size, release old and resize
     if (theMaterials == 0 || numFibers != data(1)) {
       // delete old stuff if outa date
-      if (theMaterials != 0) {
-	for (int i=0; i<numFibers; i++)
-	  delete theMaterials[i];
-	delete [] theMaterials;
-	theMaterials = nullptr;
-	// if (matData != 0)
-	//   delete [] matData;
-	// matData = 0;
+      if (theMaterials != nullptr) {
+        for (int i=0; i<numFibers; i++)
+          delete theMaterials[i];
+        delete [] theMaterials;
+        theMaterials = nullptr;
+#ifndef SHARE_FIBERS
+        if (matData != 0)
+          delete [] matData;
+        matData = 0;
+#endif
       }
 
       // create memory to hold material pointers and fiber data
       numFibers = data(1);
       sizeFibers = data(1);
       if (numFibers != 0) {
-	theMaterials = new UniaxialMaterial *[numFibers];
-	for (int j=0; j<numFibers; j++)
-	  theMaterials[j] = 0;
+        theMaterials = new UniaxialMaterial *[numFibers];
+        for (int j=0; j<numFibers; j++)
+          theMaterials[j] = 0;
 
 	// matData = std::make_shared<double[]>(new double [numFibers*2]);
-	matData.reset(new double [numFibers*2]);
-
+#ifdef SHARE_FIBERS
+	      matData.reset(new double [numFibers*2]);
+#else
+        matData = new double [numFibers*2];
+#endif
       }
     }
 
@@ -577,10 +597,10 @@ FiberSection2d::recvSelf(int commitTag, Channel &theChannel,
       // if material pointed to is blank or not of corrcet type, 
       // release old and create a new one
       if (theMaterials[i] == 0)
-	theMaterials[i] = theBroker.getNewUniaxialMaterial(classTag);
+        theMaterials[i] = theBroker.getNewUniaxialMaterial(classTag);
       else if (theMaterials[i]->getClassTag() != classTag) {
-	delete theMaterials[i];
-	theMaterials[i] = theBroker.getNewUniaxialMaterial(classTag);      
+        delete theMaterials[i];
+        theMaterials[i] = theBroker.getNewUniaxialMaterial(classTag);      
       }
 
       theMaterials[i]->setDbTag(dbTag);
@@ -629,18 +649,19 @@ FiberSection2d::Print(OPS_Stream &s, int flag)
   }
 
   if (flag == OPS_PRINT_PRINTMODEL_JSON) {
-    s << "\t\t\t{";
-	s << "\"name\": \"" << this->getTag() << "\", ";
-	s << "\"type\": \"FiberSection2d\", ";
+    s << OPS_PRINT_JSON_MATE_INDENT << "{";
+    s << "\"name\": \"" << this->getTag() << "\", ";
+    s << "\"type\": \"FiberSection2d\", ";
     s << "\"fibers\": [\n";
     for (int i = 0; i < numFibers; i++) {
-      s << "\t\t\t\t{\"coord\": [" << matData[2*i] << ", 0.0], ";
+      s << OPS_PRINT_JSON_MATE_INDENT << "  ";
+      s << "{\"coord\": [" << matData[2*i] << ", 0.0], ";
       s << "\"area\": " << matData[2*i+1] << ", ";
       s << "\"material\": " << theMaterials[i]->getTag();
       if (i < numFibers-1)
-	s << "},\n";
+        s << "},\n";
       else
-	s << "}\n";	
+        s << "}\n";	
     }
     s << "\t\t\t]}";
   }
@@ -648,7 +669,7 @@ FiberSection2d::Print(OPS_Stream &s, int flag)
 
 Response*
 FiberSection2d::setResponse(const char **argv, int argc,
-			    OPS_Stream &output)
+                            OPS_Stream &output)
 {
   Response *theResponse = 0;
   
@@ -657,7 +678,7 @@ FiberSection2d::setResponse(const char **argv, int argc,
     static double fiberLocs[10000];
     { // TODO
       for (int i = 0; i < numFibers; i++) {
-	fiberLocs[i] = matData[2*i];
+        fiberLocs[i] = matData[2*i];
       }
     }
   
@@ -679,27 +700,27 @@ FiberSection2d::setResponse(const char **argv, int argc,
       int j;
       // Find first fiber with specified material tag
       for (j = 0; j < numFibers; j++) {
-	if (matTag == theMaterials[j]->getTag()) {
-	  //ySearch = matData[2*j];
-	  ySearch = fiberLocs[j];
-	  dy = ySearch-yCoord;
-	  closestDist = dy*dy;
-	  key = j;
-	  break;
-	}
+        if (matTag == theMaterials[j]->getTag()) {
+          //ySearch = matData[2*j];
+          ySearch = fiberLocs[j];
+          dy = ySearch-yCoord;
+          closestDist = dy*dy;
+          key = j;
+          break;
+        }
       }
       // Search the remaining fibers
       for ( ; j < numFibers; j++) {
-	if (matTag == theMaterials[j]->getTag()) {
-	  //ySearch = matData[2*j];
-	  ySearch = fiberLocs[j];	  
-	  dy = ySearch-yCoord;
-	  distance = dy*dy;
-	  if (distance < closestDist) {
-	    closestDist = distance;
-	    key = j;
-	  }
-	}
+        if (matTag == theMaterials[j]->getTag()) {
+          //ySearch = matData[2*j];
+          ySearch = fiberLocs[j];	  
+          dy = ySearch-yCoord;
+          distance = dy*dy;
+          if (distance < closestDist) {
+            closestDist = distance;
+            key = j;
+          }
+        }
       }
       passarg = 4;
     }
@@ -717,15 +738,15 @@ FiberSection2d::setResponse(const char **argv, int argc,
       closestDist = fabs(dy);
       key = 0;
       for (int j = 1; j < numFibers; j++) {
-	//ySearch = matData[2*j];
-	ySearch = fiberLocs[j];	  	
-	dy = ySearch-yCoord;
-	
-	distance = dy*dy;
-	if (distance < closestDist) {
-	  closestDist = distance;
-	  key = j;
-	}
+        //ySearch = matData[2*j];
+        ySearch = fiberLocs[j];	  	
+        dy = ySearch-yCoord;
+        
+        distance = dy*dy;
+        if (distance < closestDist) {
+          closestDist = distance;
+          key = j;
+        }
       }
       passarg = 3;
     }
@@ -844,7 +865,7 @@ FiberSection2d::getResponse(int responseID, Information &sectInfo)
     int count = 0;
     for (int j = 0; j < numFibers; j++) {    
       if (theMaterials[j]->hasFailed() == true)
-	count++;
+        count++;
     }
     return sectInfo.setInt(count);
 
@@ -852,7 +873,7 @@ FiberSection2d::getResponse(int responseID, Information &sectInfo)
     int count = 0;
     for (int j = 0; j < numFibers; j++) {    
       if (theMaterials[j]->hasFailed() == true) {
-	count+=1;
+        count+=1;
       }
     }
     if (count == numFibers)
@@ -872,7 +893,6 @@ FiberSection2d::getResponse(int responseID, Information &sectInfo)
 
 
 
-// AddingSensitivity:BEGIN ////////////////////////////////////
 int
 FiberSection2d::setParameter(const char **argv, int argc, Parameter &param)
 {
@@ -893,9 +913,9 @@ FiberSection2d::setParameter(const char **argv, int argc, Parameter &param)
     // Loop over fibers to find the right material
     for (int i = 0; i < numFibers; i++)
       if (materialTag == theMaterials[i]->getTag()) {
-	int ok = theMaterials[i]->setParameter(&argv[2], argc-2, param);
-	if (ok != -1)
-	  result = ok;
+        int ok = theMaterials[i]->setParameter(&argv[2], argc-2, param);
+        if (ok != -1)
+          result = ok;
       }
     return result;
   }
@@ -921,23 +941,23 @@ FiberSection2d::setParameter(const char **argv, int argc, Parameter &param)
     // Find first fiber with specified material tag
     for (j = 0; j < numFibers; j++) {
       if (matTag == theMaterials[j]->getTag()) {
-	ySearch = matData[2*j];
-	dy = ySearch-yCoord;
-	closestDist = fabs(dy);
-	key = j;
-	break;
+        ySearch = matData[2*j];
+        dy = ySearch-yCoord;
+        closestDist = fabs(dy);
+        key = j;
+        break;
       }
     }
     // Search the remaining fibers
     for ( ; j < numFibers; j++) {
       if (matTag == theMaterials[j]->getTag()) {
-	ySearch = matData[2*j];
-	dy = ySearch-yCoord;
-	distance = fabs(dy);
-	if (distance < closestDist) {
-	  closestDist = distance;
-	  key = j;
-	}
+        ySearch = matData[2*j];
+        dy = ySearch-yCoord;
+        distance = fabs(dy);
+        if (distance < closestDist) {
+          closestDist = distance;
+          key = j;
+        }
       }
       passarg = 4;
     }
@@ -1102,15 +1122,14 @@ FiberSection2d::commitSensitivity(const Vector& defSens,
   return 0;
 }
 
-// AddingSensitivity:END ///////////////////////////////////
 
-//by SAJalali
+// by SAJalali
 double FiberSection2d::getEnergy() const
 {
-    double energy = 0;
-    for (int i = 0; i < numFibers; i++) {
-      const double A = matData[2*i+1];
-      energy += A * theMaterials[i]->getEnergy();
-    }
-    return energy;
+  double energy = 0;
+  for (int i = 0; i < numFibers; i++) {
+    const double A = matData[2*i+1];
+    energy += A * theMaterials[i]->getEnergy();
+  }
+  return energy;
 }

--- a/SRC/material/section/FiberSection2d.h
+++ b/SRC/material/section/FiberSection2d.h
@@ -33,6 +33,7 @@
 #include <Vector.h>
 #include <Matrix.h>
 #include <memory>
+#include <vector>
 
 #define SHARE_FIBERS
 class UniaxialMaterial;

--- a/SRC/material/section/FiberSection2d.h
+++ b/SRC/material/section/FiberSection2d.h
@@ -34,6 +34,7 @@
 #include <Matrix.h>
 #include <memory>
 
+#define SHARE_FIBERS
 class UniaxialMaterial;
 class Response;
 
@@ -49,7 +50,7 @@ class FiberSection2d : public FrameSection
 #endif
     ~FiberSection2d();
 
-    const char *getClassType(void) const {return "FiberSection2d";};
+    const char *getClassType(void) const {return "FiberSection2d";}
 
     int   setTrialSectionDeformation(const Vector &deforms); 
     const Vector &getSectionDeformation(void);
@@ -67,9 +68,8 @@ class FiberSection2d : public FrameSection
     int getOrder (void) const;
     
     int sendSelf(int cTag, Channel &theChannel);
-    int recvSelf(int cTag, Channel &theChannel, 
-		 FEM_ObjectBroker &theBroker);
-    void Print(OPS_Stream &s, int flag = 0);
+    int recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &);
+    void Print(OPS_Stream &s, int flag);
 	    
     Response *setResponse(const char **argv, int argc, 
 			  OPS_Stream &s);
@@ -79,8 +79,7 @@ class FiberSection2d : public FrameSection
 
     // AddingSensitivity:BEGIN //////////////////////////////////////////
     int setParameter(const char **argv, int argc, Parameter &param);
-    const Vector& getStressResultantSensitivity(int gradIndex,
-						bool conditional);
+    const Vector& getStressResultantSensitivity(int gradIndex,	bool conditional);
     const Vector& getSectionDeformationSensitivity(int gradIndex);
     const Matrix& getInitialTangentSensitivity(int gradIndex);
     int commitSensitivity(const Vector& sectionDeformationGradient,
@@ -88,14 +87,23 @@ class FiberSection2d : public FrameSection
     // AddingSensitivity:END ///////////////////////////////////////////
 
     double getEnergy() const; // by SAJalali
-    int   getIntegral(Field field, State state, double& value) const override final;
+    int   getIntegral(Field field, State state, double& value) const final;
 
   protected:
     
-    //  private:
+  private:
+    struct FiberData {
+      double area;
+      double y;
+    };
+    const std::shared_ptr<std::vector<FiberData>> fibers;
     int numFibers, sizeFibers;         // number of fibers in the section
     UniaxialMaterial **theMaterials;   // array of pointers to materials
-    std::shared_ptr<double[]> matData; // data for the materials [yloc and area]
+#ifdef SHARE_FIBERS
+    std::shared_ptr<double[]> matData;
+#else
+    double* matData; // data for the materials [yloc and area]
+#endif
     double   kData[4];                 // data for ks matrix 
     double   sData[2];                 // data for s vector 
     

--- a/SRC/material/ucsd/NewTemplate3Dep/DM04_alpha_Eij.cpp
+++ b/SRC/material/ucsd/NewTemplate3Dep/DM04_alpha_Eij.cpp
@@ -111,8 +111,9 @@ TensorEvolution* DM04_alpha_Eij::newObj()
     return nObj;
 }
 
-const straintensor& DM04_alpha_Eij::Hij(const straintensor& plastic_flow, const stresstensor& Stre, 
-                                        const straintensor& Stra, const MaterialParameter& material_parameter)
+const straintensor& 
+DM04_alpha_Eij::Hij(const straintensor& plastic_flow, const stresstensor& Stre, 
+                    const straintensor& Stra, const MaterialParameter& material_parameter)
 {
     stresstensor alpha_alpha_in;
     double a_in = 0.0;
@@ -123,7 +124,7 @@ const straintensor& DM04_alpha_Eij::Hij(const straintensor& plastic_flow, const 
     double lambda_c = getlambda_c(material_parameter);
     double xi = getxi(material_parameter);
     double Pat = getPat(material_parameter);
-    double m = getm(material_parameter);
+    // double m = getm(material_parameter);
     double M_cal = getM_cal(material_parameter);
     double cc = getcc(material_parameter);
     double nb = getnb(material_parameter);
@@ -219,57 +220,55 @@ const straintensor& DM04_alpha_Eij::Hij(const straintensor& plastic_flow, const 
 }
 
 // to get e0
-//================================================================================
-double DM04_alpha_Eij::gete0(const MaterialParameter& material_parameter) const
+double 
+DM04_alpha_Eij::gete0(const MaterialParameter& material_parameter) const
 {
     return getParameters(material_parameter, e0_index);
 }
 
 // to get e_r
-//================================================================================
-double DM04_alpha_Eij::gete_r(const MaterialParameter& material_parameter) const
+double 
+DM04_alpha_Eij::gete_r(const MaterialParameter& material_parameter) const
 {
     return getParameters(material_parameter, e_r_index);
 }
 
 // to get lambda_c
-//================================================================================
-double DM04_alpha_Eij::getlambda_c(const MaterialParameter& material_parameter) const
+double 
+DM04_alpha_Eij::getlambda_c(const MaterialParameter& material_parameter) const
 {
     return getParameters(material_parameter, lambda_c_index);
 }
 
 // to get xi
 //================================================================================
-double DM04_alpha_Eij::getxi(const MaterialParameter& material_parameter) const
+double 
+DM04_alpha_Eij::getxi(const MaterialParameter& material_parameter) const
 {
     return getParameters(material_parameter, xi_index);
 
 }
 
 // to get Pat
-//================================================================================
 double DM04_alpha_Eij::getPat(const MaterialParameter& material_parameter) const
 {
-    return getParameters(material_parameter, Pat_index);
+  return getParameters(material_parameter, Pat_index);
 }
 
 // to get m
 //================================================================================
 double DM04_alpha_Eij::getm(const MaterialParameter& material_parameter) const
 {
-    return getParameters(material_parameter, m_index);
+  return getParameters(material_parameter, m_index);
 }
 
 // to get M
-//================================================================================
 double DM04_alpha_Eij::getM_cal(const MaterialParameter& material_parameter) const
 {
     return getParameters(material_parameter, M_cal_index);
 }
 
 // to get c
-//================================================================================
 double DM04_alpha_Eij::getcc(const MaterialParameter& material_parameter) const
 {
     return getParameters(material_parameter, cc_index);

--- a/SRC/material/ucsd/NewTemplate3Dep/DM04_z_Eij.cpp
+++ b/SRC/material/ucsd/NewTemplate3Dep/DM04_z_Eij.cpp
@@ -74,10 +74,11 @@ TensorEvolution* DM04_z_Eij::newObj()
     return nObj;
 }
 
-const straintensor& DM04_z_Eij::Hij(const straintensor& plastic_flow, const stresstensor& Stre, 
-                                    const straintensor& Stra, const MaterialParameter& material_parameter)
+const straintensor& 
+DM04_z_Eij::Hij(const straintensor& plastic_flow, const stresstensor& Stre, 
+                const straintensor& Stra, const MaterialParameter& material_parameter)
 {
-    double m = getm(material_parameter);
+    // double m = getm(material_parameter);
     double c_z = getc_z(material_parameter);
     double z_max = getz_max(material_parameter);        
     stresstensor alpha = getalpha(material_parameter);
@@ -105,8 +106,8 @@ const straintensor& DM04_z_Eij::Hij(const straintensor& plastic_flow, const stre
 }
 
 // to get m
-//================================================================================
-double DM04_z_Eij::getm(const MaterialParameter& material_parameter) const
+double 
+DM04_z_Eij::getm(const MaterialParameter& material_parameter) const
 {
     if ( m_index <= material_parameter.getNum_Material_Parameter() && m_index > 0)
         return material_parameter.getMaterial_Parameter(m_index-1);
@@ -117,8 +118,8 @@ double DM04_z_Eij::getm(const MaterialParameter& material_parameter) const
 }
 
 // to get c_z
-//================================================================================
-double DM04_z_Eij::getc_z(const MaterialParameter& material_parameter) const
+double 
+DM04_z_Eij::getc_z(const MaterialParameter& material_parameter) const
 {
     if ( c_z_index <= material_parameter.getNum_Material_Parameter() && c_z_index > 0)
         return material_parameter.getMaterial_Parameter(c_z_index-1);
@@ -129,8 +130,8 @@ double DM04_z_Eij::getc_z(const MaterialParameter& material_parameter) const
 }
 
 // to get c
-//================================================================================
-double DM04_z_Eij::getz_max(const MaterialParameter& material_parameter) const
+double 
+DM04_z_Eij::getz_max(const MaterialParameter& material_parameter) const
 {
     if ( z_max_index <= material_parameter.getNum_Material_Parameter() && z_max_index > 0)
         return material_parameter.getMaterial_Parameter(z_max_index-1);

--- a/SRC/opensees/openseespy.pyi
+++ b/SRC/opensees/openseespy.pyi
@@ -63,7 +63,7 @@ class _Elements:
 
     @overload
     def element(self,
-                __elmType: Literal["forceBeamColumn"],
+                __elmType: Literal["ForceFrame"],
                 tag: int,
                 nodes: tuple,
                 nip: int,
@@ -139,7 +139,50 @@ class _Output:
         Get the displacement of a node in a specified degree of freedom.
         """
 
-class Model(_Materials,_Elements,_Algorithm):
+    def getNodeTags(self) -> list[int]:
+        """
+        Get a list of all node tags in the model.
+        """
+
+    def nodeCoord(self, node: int, index: int=None) -> list[float] | float:
+        """
+        Get the coordinates of a node.
+        """
+
+    @overload
+    def nodeDisp(self, node: int) -> list[float]:
+        """
+        Return the displacements of a node.
+        """
+
+    @overload
+    def nodeDisp(self, node: int, dof: int) -> float:
+        """
+        Return the displacement of a node.
+        """
+
+    @overload
+    def nodeReaction(self, node: int) -> list[float]:
+        """
+        Get the reaction forces at a node.
+        """
+    @overload
+    def nodeReaction(self, node: int, dof: int) -> float:
+        """
+        Get the reaction force(s) at a node.
+        """
+
+    def getEleTags(self) -> list[int]:
+        """
+        Get a list of all element tags in the model.
+        """
+
+    def eleResponse(self, ele: int, responseType: str) -> list[float]:
+        """
+        Get the response of an element.
+        """
+
+class Model(_Materials,_Elements,_Algorithm, _Output):
     def node(self, tag: int, coords: tuple, *args, **kwargs) -> int:
         """
         Create a node with the specified tag and coordinates.
@@ -158,14 +201,4 @@ class Model(_Materials,_Elements,_Algorithm):
     def load(self, node: int, *args):
         """
         Apply loads to a node.
-        """
-    
-    def getNodeTags(self) -> list[int]:
-        """
-        Get a list of all node tags in the model.
-        """
-
-    def nodeCoord(self, node: int, index: int=None) -> list[float] | float:
-        """
-        Get the coordinates of a node.
         """

--- a/SRC/runtime/commands/CMakeLists.txt
+++ b/SRC/runtime/commands/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(OPS_Runtime PRIVATE
     "modeling/geomTransf.cpp"
 
     "modeling/element.cpp"
+    "modeling/element/prism.cpp"
     "modeling/element/frames.cpp"
     "modeling/element/shells.cpp"
     "modeling/element/brick.cpp"

--- a/SRC/runtime/commands/modeling/element/prism.cpp
+++ b/SRC/runtime/commands/modeling/element/prism.cpp
@@ -605,7 +605,8 @@ Parse_ElasticBeam(ClientData clientData, Tcl_Interp *interp, int argc,
                                  options.mass_type,
                                  use_mass,
                                  options.relz_flag,
-                                 options.geom_flag);
+                                 options.geom_flag,
+                                 options.shear_flag);
     }
 
     else if (strcmp(argv[1], "PrismFrame") == 0) {

--- a/SRC/runtime/commands/modeling/section/frame.cpp
+++ b/SRC/runtime/commands/modeling/section/frame.cpp
@@ -144,37 +144,90 @@ TclCommand_newElasticSectionTemplate(ClientData clientData, Tcl_Interp *interp,
         }
         if ((GetDoubleParam(interp, domain, argv[i], &consts.A, parameters[int(Position::A)]) != TCL_OK) ||
             consts.A <= 0.0) {
-          opserr << OpenSees::PromptParseError << "invalid area.\n";
+          opserr << OpenSees::PromptParseError 
+                 << "invalid area."
+                 << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
-
+        
+        // Default to A if Ay or Az is not specified
         if (tracker.contains(Position::ky))
-          consts.Ay = consts.A; // Default to A if Ay is not specified
+          consts.Ay = consts.A;
         if (tracker.contains(Position::kz))
-          consts.Az = consts.A; // Default to A if Az is not specified
+          consts.Az = consts.A;
 
         tracker.consume(Position::A);
       }
 
+      // Shear corrections
       else if ((strcmp(argv[i], "-shear-y") == 0) ||
                (strcmp(argv[i], "-Ay") == 0)) {
-        use_shear = true;
-        if (argc == ++i || Tcl_GetDouble (interp, argv[i], &consts.Ay) != TCL_OK) {
-          opserr << OpenSees::PromptParseError << "invalid shear area.\n";
+        if (argc == ++i || Tcl_GetDouble(interp, argv[i], &consts.Ay) != TCL_OK) {
+          opserr << OpenSees::PromptParseError 
+                 << "invalid shear area."
+                 << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
+        use_shear = true;
         construct_full = true;
         tracker.consume(Position::ky);
       }
-
       else if ((strcmp(argv[i], "-shear-z") == 0) ||
                (strcmp(argv[i], "-Az") == 0)) {
-        if (argc == ++i || Tcl_GetDouble (interp, argv[i], &consts.Az) != TCL_OK) {
-          opserr << OpenSees::PromptParseError << "invalid shear area.\n";
+        if (argc == ++i || Tcl_GetDouble(interp, argv[i], &consts.Az) != TCL_OK) {
+          opserr << OpenSees::PromptParseError 
+                 << "invalid shear area."
+                 << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
+        use_shear = true;
         construct_full = true;
         tracker.consume(Position::kz);
+      }
+      else if ((strcmp(argv[i], "-ky") == 0) || (strcmp(argv[i], "-kz") == 0)) {
+        // Shear corrections as fraction of area
+        double k;
+        if (argc == ++i || Tcl_GetDouble (interp, argv[i], &k) != TCL_OK) {
+          opserr << OpenSees::PromptParseError 
+                 << "invalid shear correction."
+                 << OpenSees::SignalMessageEnd;
+          return TCL_ERROR;
+        }
+
+        double A;
+        bool have_A = false;
+        // If we have already read A, use it; otherwise, find it. A is required.
+        if (tracker.contains(Position::A)) {
+          // Find A from parameters
+          for (int j=0; j<argc; j++) {
+            if ((strcmp(argv[j], "-area") == 0) || (strcmp(argv[j], "-A") == 0)) {
+              if ( argc <= ++j )
+                // -A flag without value; wait for area handler above to catch it
+                break;
+              if (Tcl_GetDouble(interp, argv[j], &A) != TCL_OK)
+                break;
+              have_A = true;
+              break;
+            }
+          }
+        }
+        else {
+          A = consts.A;
+          have_A = true;
+        }
+        if (!have_A || A <= 0.0)
+          continue; // Let area handler above catch missing/invalid A;
+
+        if (strcmp(argv[i-1], "-ky") == 0) {
+          consts.Ay = A * k;
+          tracker.consume(Position::ky);
+        }
+        else if (strcmp(argv[i-1], "-kz") == 0) {
+          consts.Az = A * k;
+          tracker.consume(Position::kz);
+        }
+        use_shear = true;
+        construct_full = true;
       }
 
       else if ((strcmp(argv[i], "-inertia") == 0) ||
@@ -388,7 +441,6 @@ TclCommand_newElasticSectionTemplate(ClientData clientData, Tcl_Interp *interp,
             break;
           }
         }
-
         case Position::kz: {
           double kz;
           if (Tcl_GetDouble (interp, argv[i], &kz) != TCL_OK) {


### PR DESCRIPTION
This pull request introduces a new `Prism` struct to encapsulate cross-sectional properties for frame elements, refactors the way these properties are initialized and accessed in `PrismFrame2d`, and makes several related code improvements for clarity and maintainability. Additionally, it includes minor bug fixes, code cleanups, and consistency improvements across frame element and coordinate transformation classes.

**Key changes:**

### 1. Introduction of `Prism` Struct for Section Properties
- Added a new `Prism` struct in `OpenSees::Frame` to encapsulate geometric and material properties (e.g., area, moments of inertia, shear areas, Young's modulus, shear modulus) for frame sections. The struct includes logic to extract these properties from a `FrameSection` object and sets up derived quantities as needed. (`SRC/element/Frame/Prism.h`)

### 2. Refactor of `PrismFrame2d` Construction and Property Initialization
- Updated `PrismFrame2d` to use the new `Prism` struct for extracting and storing section properties, replacing direct calls to `section.getIntegral`. This centralizes property handling and improves maintainability. (`SRC/element/Frame/PrismFrame2d.cpp`) [[1]](diffhunk://#diff-013134511f5b6efe922425f4bcdaacae106bb498b007f811debd4cb0d4df6600L94-R104) [[2]](diffhunk://#diff-013134511f5b6efe922425f4bcdaacae106bb498b007f811debd4cb0d4df6600R127-R139)
- Included the new header and updated namespace usage for clarity and consistency. (`SRC/element/Frame/PrismFrame2d.cpp`) [[1]](diffhunk://#diff-013134511f5b6efe922425f4bcdaacae106bb498b007f811debd4cb0d4df6600R14) [[2]](diffhunk://#diff-013134511f5b6efe922425f4bcdaacae106bb498b007f811debd4cb0d4df6600L33-R34)

### 3. Consistency and Bug Fixes in Frame Element Classes
- Moved `getIntegral` methods in `EulerFrame3d`, `EulerDeltaFrame3d`, and `ForceFrame3d` from `virtual`/protected to private or non-virtual, reflecting their actual usage and improving encapsulation. (`SRC/element/Frame/EulerFrame3d.h`, `SRC/element/Frame/EulerDeltaFrame3d.h`, `SRC/element/Frame/ForceFrame3d.h`) [[1]](diffhunk://#diff-a2b61b4a7991258824b23edc2b0bd271b0330453bb92db94c1b4a84d00af60cfL86) [[2]](diffhunk://#diff-a2b61b4a7991258824b23edc2b0bd271b0330453bb92db94c1b4a84d00af60cfR105) [[3]](diffhunk://#diff-5ad0720e0d3a173f7e8bcf3510df03e79f63dc05b1ca500643151c7030df9974L71-R77) [[4]](diffhunk://#diff-f64eb45045b0fe69917e2723cfb9486967fd10b066c43e96f50296bbb26aad15L108) [[5]](diffhunk://#diff-f64eb45045b0fe69917e2723cfb9486967fd10b066c43e96f50296bbb26aad15R122-R123)

### 4. Improvements and Cleanups in Coordinate Transformation Classes
- Improved comments, section ordering, and clarity in `EuclidFrameTransf` methods, especially around isometry, rotation, and projection steps. This makes the code easier to follow and maintain. (`SRC/coordTransformation/Frame/EuclidFrameTransf.tpp`) [[1]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L250-R250) [[2]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L264-R272) [[3]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L285-R285) [[4]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L298-R298) [[5]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1R319-R331) [[6]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L338-R348) [[7]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L355-R357) [[8]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L385-R387) [[9]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1L420-L422) [[10]](diffhunk://#diff-fc50857b6aa5e40f1508f247f48b889b1eaf72765faa9bc371c6147dea0936e1R476-R478)
- Fixed static vector initialization in `BasicFrameTransf3d` methods for trial displacement and velocity, preventing potential uninitialized data issues. (`SRC/coordTransformation/Frame/BasicFrameTransf.tpp`) [[1]](diffhunk://#diff-d16fa421101dc326c62284d66c124621bac4b3a5782b49d892f2ed7123322e93L130-R130) [[2]](diffhunk://#diff-d16fa421101dc326c62284d66c124621bac4b3a5782b49d892f2ed7123322e93L165-R165)
- Added a TODO comment for future implementation in `CrisfieldIsometry::getRotationJacobian`. (`SRC/coordTransformation/Frame/Isometry/CrisfieldIsometry.h`)

### 5. Miscellaneous Fixes and Cleanups
- Improved JSON output formatting in `LinearCrdTransf2d::Print` for consistency with other output. (`SRC/coordTransformation/LinearCrdTransf2d.cpp`)
- Minor CMake cleanup: removed redundant source from `OPS_Runtime` target. (`SRC/element/Frame/Elastic/CMakeLists.txt`)
- Fixed matrix initialization in mass and stiffness matrix computations in `PrismFrame2d` to ensure proper type construction. (`SRC/element/Frame/PrismFrame2d.cpp`) [[1]](diffhunk://#diff-013134511f5b6efe922425f4bcdaacae106bb498b007f811debd4cb0d4df6600L360-R380) [[2]](diffhunk://#diff-013134511f5b6efe922425f4bcdaacae106bb498b007f811debd4cb0d4df6600L414-R428)
- Minor bug fix: ensured `shear_flag` is initialized in all constructors. (`SRC/element/Frame/PrismFrame2d.cpp`)
