### PR TITLE
Keep Graph::getNumEdge consistent with vertex adjacency lists

### DIFF
--- a/SRC/analysis/model/AnalysisModel.cpp
+++ b/SRC/analysis/model/AnalysisModel.cpp
@@ -20,11 +20,11 @@
 //
 // Purpose: This file contains the class definition for AnalysisModel
 // AnalysisModel is a container class. The class is responsible for holding
-// and providing access to the Elements, Nodes, LoadCases, SP_Constraints
-// and MP_Constraints. These objects are all added to the AnalysisModel by a
+// and providing access to the Elements, Nodes, LoadCases, SP_Constraints 
+// and MP_Constraints. These objects are all added to the AnalysisModel by a 
 // ModelBuilder.
 //
-// Written: fmk
+// Written: fmk 
 // Created: Fri Sep 20 15:27:47: 1996
 // Revision: A
 //
@@ -59,7 +59,7 @@
 #define START_VERTEX_NUM 0
 
 
-static int
+static int 
 ApproxDOF(Domain& domain)
 {
   int nf = 0;
@@ -94,7 +94,7 @@ AnalysisModel::AnalysisModel(Domain& domain)
 
   theDOFs->setSize(ApproxDOF(domain));
   theFEs->setSize(domain.getNumElements());
-}
+} 
 
 
 
@@ -117,16 +117,16 @@ AnalysisModel::~AnalysisModel()
     delete theDOFiter;
 
   if (myGroupGraph != nullptr) {
-    delete myGroupGraph;
-  }
-
+    delete myGroupGraph;    
+  }        
+  
   if (myDOFGraph != nullptr) {
     delete myDOFGraph;
   }
 
   if (modalDamping != nullptr)
     delete modalDamping;
-}
+}    
 
 void
 AnalysisModel::setLinks(Domain &theDomain, ConstraintHandler &theHandler)
@@ -148,8 +148,8 @@ AnalysisModel::addFE_Element(FE_Element *theElement)
   int tag = theElement->getTag();
   TaggedObject *other = theFEs->getComponentPtr(tag);
   if (other != 0) {
-    opserr << "AnalysisModel::addFE_Element - element with tag "
-           << tag << " already exists in model\n";
+    opserr << "AnalysisModel::addFE_Element - element with tag " 
+           << tag << " already exists in model\n"; 
     return false;
   }
 
@@ -179,7 +179,7 @@ AnalysisModel::addDOF_Group(DOF_Group *theGroup)
   TaggedObject *other = theDOFs->getComponentPtr(tag);
   if (other != nullptr) {
     opserr << "AnalysisModel::addDOF_Group - group with tag "
-           << tag << " already exists in model\n";
+           << tag << " already exists in model\n"; 
     return false;
   }
 
@@ -194,33 +194,33 @@ AnalysisModel::addDOF_Group(DOF_Group *theGroup)
 
 
 void
-AnalysisModel::clearAll()
+AnalysisModel::clearAll() 
 {
   // if the graphs have been constructed delete them
   this->clearDOFGroupGraph();
 
-  this->clearDOFGraph();
+  this->clearDOFGraph(); 
 
   theFEs->clearAll();
   theDOFs->clearAll();
-
+  
   numFE_Ele =0;
   numDOF_Grp = 0;
   numEqn = 0;
 
   if (myHandler != nullptr)
     myHandler->clearAll();
-
+  
   if (modalDamping != nullptr)
     delete modalDamping;
   modalDamping = nullptr;
 
-
+  
   // for the nodes reset the DOF_Group pointers to 0
   Domain *theDomain = this->getDomainPtr();
   if (theDomain == nullptr)
     return;
-
+  
   NodeIter &theNod = theDomain->getNodes();
   Node *nodPtr;
   while ((nodPtr = theNod()) != nullptr)
@@ -228,7 +228,7 @@ AnalysisModel::clearAll()
 }
 
 void
-AnalysisModel::clearDOFGraph()
+AnalysisModel::clearDOFGraph() 
 {
   if (myDOFGraph != nullptr)
     delete myDOFGraph;
@@ -237,11 +237,11 @@ AnalysisModel::clearDOFGraph()
 }
 
 void
-AnalysisModel::clearDOFGroupGraph()
+AnalysisModel::clearDOFGroupGraph() 
 {
   if (myGroupGraph != nullptr)
-    delete myGroupGraph;
-
+    delete myGroupGraph;    
+  
   myGroupGraph = nullptr;
 }
 
@@ -281,7 +281,7 @@ AnalysisModel::getDOFs()
   return *theDOFiter;
 }
 
-void
+void 
 AnalysisModel::setNumEqn(int theNumEqn)
 {
   if (modalDamping != nullptr && (numEqn != theNumEqn)) {
@@ -292,7 +292,7 @@ AnalysisModel::setNumEqn(int theNumEqn)
   numEqn = theNumEqn;
 }
 
-int
+int 
 AnalysisModel::getNumEqn() const
 {
   return numEqn;
@@ -311,7 +311,7 @@ AnalysisModel::getDOFGraph()
     //
     // create a vertex for each dof
     //
-
+    
     DOF_Group *dofPtr =0;
     DOF_GrpIter &theDOFs = this->getDOFs();
     while ((dofPtr = theDOFs()) != 0) {
@@ -322,7 +322,7 @@ AnalysisModel::getDOFGraph()
         if (dofTag >= START_EQN_NUM) {
           Vertex *vertexPtr = myDOFGraph->getVertexPtr(dofTag);
           if (vertexPtr == 0) {
-            Vertex *vertexPtr = new Vertex(dofTag, dofTag);
+            Vertex *vertexPtr = new Vertex(dofTag, dofTag);      
             if (vertexPtr == 0) {
               opserr << "WARNING AnalysisModel::getDOFGraph";
               opserr << " - Not Enough Memory to create " << i+1 << "th Vertex\n";
@@ -336,33 +336,33 @@ AnalysisModel::getDOFGraph()
         }
       }
     }
-
+    
     // now add the edges, by looping over the FE_elements, getting their
     // IDs and adding edges between DOFs for equation numbers >= START_EQN_NUM
-
+    
     FE_Element *elePtr =0;
     FE_EleIter &eleIter = this->getFEs();
-
+    
     myDOFGraph->startAddEdge();
     while((elePtr = eleIter()) != 0) {
       const ID &id = elePtr->getID();
       const int size = id.Size();
       for (int i=0; i<size; i++) {
         int eqn1 = id(i);
-
+        
         // if eqnNum of DOF is a valid eqn number add an edge
         // to all other DOFs with valid eqn numbers.
         if (eqn1 >=START_EQN_NUM) {
           for (int j=i+1; j<size; j++) {
             int eqn2 = id(j);
-            if (eqn2 >= START_EQN_NUM)
+            if (eqn2 >=START_EQN_NUM)
               myDOFGraph->addEdgeFast(eqn1-START_EQN_NUM+START_VERTEX_NUM,
                                   eqn2-START_EQN_NUM+START_VERTEX_NUM);
           }
         }
       }
     }
-  }
+  }    
 
   return *myDOFGraph;
 }
@@ -377,7 +377,7 @@ AnalysisModel::getDOFGroupGraph()
     // myGroupGraph = new Graph(numVertex);
     MapOfTaggedObjects *graphStorage = new MapOfTaggedObjects();
     myGroupGraph = new Graph(*graphStorage);
-
+        
 
     // now create the vertices with a reference equal to the DOF_Group number.
     // and a tag which ranges from 0 through numVertex-1
@@ -395,7 +395,7 @@ AnalysisModel::getDOFGroupGraph()
 
     // now add the edges, by looping over the Elements, getting their
     // IDs and adding edges between DOFs for equation numbers >= START_EQN_NUM
-
+    
     FE_Element *elePtr;
     FE_EleIter &eleIter = this->getFEs();
 
@@ -404,7 +404,7 @@ AnalysisModel::getDOFGroupGraph()
       int size = id.Size();
       for (int i=0; i<size; i++) {
         int dof1 = id(i);
-        for (int j=0; j<size; j++)
+        for (int j=0; j<size; j++) 
           if (i != j) {
             int dof2 = id(j);
             myGroupGraph->addEdge(dof1,dof2);
@@ -419,9 +419,9 @@ AnalysisModel::getDOFGroupGraph()
 
 
 
-void
+void 
 AnalysisModel::setResponse(const Vector &disp,
-                           const Vector &vel,
+                           const Vector &vel, 
                            const Vector &accel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
@@ -438,7 +438,7 @@ AnalysisModel::setResponse(const Vector &disp,
 void
 AnalysisModel::setStateGradient(
                     const Vector &u,
-                    const Vector &v,
+                    const Vector &v, 
                     const Vector &a,
                     int grad, int ngrad)
 {
@@ -450,11 +450,11 @@ AnalysisModel::setStateGradient(
   }
 }
 
-void
+void 
 AnalysisModel::getStateGradient(
-                    Vector &du,
-                    Vector &dv,
-                    Vector &da,
+                    Vector &du, 
+                    Vector &dv, 
+                    Vector &da, 
                     int grad)
 {
 
@@ -481,19 +481,19 @@ AnalysisModel::getStateGradient(
   }
 }
 
-int
+int 
 AnalysisModel::commitGradient(int gradNum, int numGrads)
 {
   // Loop through the FE_Elements and set unconditional sensitivities
   FE_Element *elePtr;
-  FE_EleIter &theEles = this->getFEs();
+  FE_EleIter &theEles = this->getFEs();    
   while ((elePtr = theEles()) != nullptr)
     elePtr->commitSensitivity(gradNum, numGrads);
 
   return 0;
 }
 
-void
+void 
 AnalysisModel::setDisp(const Vector &disp)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
@@ -501,30 +501,30 @@ AnalysisModel::setDisp(const Vector &disp)
 
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->setNodeDisp(disp);
-}
-
-void
+}        
+        
+void 
 AnalysisModel::setVel(const Vector &vel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
   DOF_Group   *dofPtr;
-
+  
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->setNodeVel(vel);
 }
+        
 
-
-void
+void 
 AnalysisModel::setAccel(const Vector &accel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
   DOF_Group   *dofPtr;
-
-  while ((dofPtr = theDOFGrps()) != 0)
-    dofPtr->setNodeAccel(accel);
+  
+  while ((dofPtr = theDOFGrps()) != 0) 
+    dofPtr->setNodeAccel(accel);        
 }
 
-void
+void 
 AnalysisModel::incrDisp(const Vector &disp)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
@@ -533,27 +533,27 @@ AnalysisModel::incrDisp(const Vector &disp)
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->incrNodeDisp(disp);
 }
-
-void
+        
+void 
 AnalysisModel::incrVel(const Vector &vel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
-  DOF_Group         *dofPtr;
+  DOF_Group         *dofPtr;    
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->incrNodeVel(vel);
 }
 
 
 #if 0
-void
+void 
 AnalysisModel::incrAccel(const Vector &accel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
     DOF_Group         *dofPtr;
-
-    while ((dofPtr = theDOFGrps()) != 0)
-      dofPtr->incrNodeAccel(accel);
-}
+    
+    while ((dofPtr = theDOFGrps()) != 0) 
+      dofPtr->incrNodeAccel(accel);        
+}        
 #endif
 
 
@@ -579,7 +579,7 @@ AnalysisModel::getState(Vector &U, Vector &Udot, Vector &Udotdot, int flag)
           U(loc) = disp(i);
         }
     }
-
+    
     const Vector &vel = dofPtr->getCommittedVel();
     for (int i=0; i < idSize; i++)  {
       int loc = id(i);
@@ -587,7 +587,7 @@ AnalysisModel::getState(Vector &U, Vector &Udot, Vector &Udotdot, int flag)
         Udot(loc) = vel(i);
       }
     }
-
+    
     const Vector &accel = dofPtr->getCommittedAccel();
     for (int i=0; i < idSize; i++)  {
       int loc = id(i);
@@ -601,7 +601,7 @@ AnalysisModel::getState(Vector &U, Vector &Udot, Vector &Udotdot, int flag)
 }
 
 
-int
+int 
 AnalysisModel::applyResidual(Integrator& assm, LinearSOE& soe)
 {
 
@@ -620,7 +620,7 @@ AnalysisModel::applyResidual(Integrator& assm, LinearSOE& soe)
   // loop through the FE_Elements and add the residual
   // same as IncrementalIntegrator::formElementResidual
   FE_Element *elePtr;
-  FE_EleIter &theEles2 = this->getFEs();
+  FE_EleIter &theEles2 = this->getFEs();    
   while ((elePtr = theEles2()) != nullptr) {
     if (soe.addB(elePtr->getResidual(&assm), elePtr->getID()) < 0) [[unlikely]] {
       res = -2;
@@ -632,7 +632,7 @@ AnalysisModel::applyResidual(Integrator& assm, LinearSOE& soe)
 
 
 
-int
+int 
 AnalysisModel::applyInertia(const Vector &v, Vector &res)
 {
   // int n = v.Size();
@@ -643,7 +643,7 @@ AnalysisModel::applyInertia(const Vector &v, Vector &res)
 
   // loop over the FE_Elements
   FE_Element *elePtr;
-  FE_EleIter &theEles = this->getFEs();
+  FE_EleIter &theEles = this->getFEs();    
   while((elePtr = theEles()) != nullptr) {
     const Vector &b = elePtr->getM_Force(v, 1.0);
     res.Assemble(b, elePtr->getID(), 1.0);
@@ -653,14 +653,14 @@ AnalysisModel::applyInertia(const Vector &v, Vector &res)
   DOF_Group *dofPtr;
   DOF_GrpIter &theDofs = this->getDOFs();
   while ((dofPtr = theDofs()) != nullptr) {
-    const Vector &a = dofPtr->getM_Force(v, 1.0);
+    const Vector &a = dofPtr->getM_Force(v, 1.0);      
     res.Assemble(a, dofPtr->getID(), 1.0);
   }
   return 0;
 }
 
 
-int
+int 
 AnalysisModel::applyInertia(const Vector &v, LinearSOE& soe, double fact)
 {
   assert(v.Size() == numEqn);
@@ -668,7 +668,7 @@ AnalysisModel::applyInertia(const Vector &v, LinearSOE& soe, double fact)
 
   // loop over the FE_Elements
   FE_Element *elePtr;
-  FE_EleIter &theEles = this->getFEs();
+  FE_EleIter &theEles = this->getFEs();    
   while((elePtr = theEles()) != nullptr) {
     const Vector &b = elePtr->getM_Force(v, 1.0);
     soe.addB(b, elePtr->getID(), fact);
@@ -678,14 +678,14 @@ AnalysisModel::applyInertia(const Vector &v, LinearSOE& soe, double fact)
   DOF_Group *dofPtr;
   DOF_GrpIter &theDofs = this->getDOFs();
   while ((dofPtr = theDofs()) != 0) {
-    const Vector &a = dofPtr->getM_Force(v, 1.0);
+    const Vector &a = dofPtr->getM_Force(v, 1.0);      
     soe.addB(a, dofPtr->getID(), fact);
   }
   return 0;
 }
 
 
-void
+void 
 AnalysisModel::setNumEigenvectors(int numEigenvectors)
 {
   Node *theNode;
@@ -695,18 +695,18 @@ AnalysisModel::setNumEigenvectors(int numEigenvectors)
 }
 
 
-void
+void 
 AnalysisModel::setEigenvalues(const Vector &eigenvalues)
 {
   myDomain->setEigenvalues(eigenvalues);
-}
+}        
 
 
 const Vector &
 AnalysisModel::getEigenvalues()
 {
   return myDomain->getEigenvalues();
-}
+}        
 
 
 
@@ -717,13 +717,13 @@ AnalysisModel::getModalDampingFactors()
 }
 
 
-bool
+bool 
 AnalysisModel::inclModalDampingMatrix()
 {
   return myDomain->inclModalDampingMatrix();
 }
 
-int
+int 
 AnalysisModel::setModalDamping(const Vector &modalDampingFactors)
 {
   if (modalDamping != nullptr)
@@ -733,18 +733,18 @@ AnalysisModel::setModalDamping(const Vector &modalDampingFactors)
   return 0;
 }
 
-void
+void 
 AnalysisModel::setEigenvector(int mode, const Vector &eigenvalue)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
   DOF_Group   *dofPtr;
+  
+  while ((dofPtr = theDOFGrps()) != nullptr) 
+    dofPtr->setEigenvector(mode, eigenvalue);        
+}        
 
-  while ((dofPtr = theDOFGrps()) != nullptr)
-    dofPtr->setEigenvector(mode, eigenvalue);
-}
 
-
-void
+void 
 AnalysisModel::applyLoadDomain(double time)
 {
   assert(myDomain != nullptr);
@@ -754,7 +754,7 @@ AnalysisModel::applyLoadDomain(double time)
 
 
 int
-AnalysisModel::applyLoadGradient()
+AnalysisModel::applyLoadGradient() 
 {
   // 1) Zero the unbalaced load
   Node *node;
@@ -877,7 +877,7 @@ AnalysisModel::getDomainPtr() const
   return myDomain;
 }
 
-void
+void 
 AnalysisModel::Print(OPS_Stream &s, int flag)
 {
   opserr << "{\n";
@@ -911,8 +911,7 @@ AnalysisModel::sendSelf(int cTag, Channel &theChannel)
 
 
 int
-AnalysisModel::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
+AnalysisModel::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker) 
 {
   return 0;
 }
-

--- a/SRC/analysis/model/AnalysisModel.cpp
+++ b/SRC/analysis/model/AnalysisModel.cpp
@@ -20,11 +20,11 @@
 //
 // Purpose: This file contains the class definition for AnalysisModel
 // AnalysisModel is a container class. The class is responsible for holding
-// and providing access to the Elements, Nodes, LoadCases, SP_Constraints 
-// and MP_Constraints. These objects are all added to the AnalysisModel by a 
+// and providing access to the Elements, Nodes, LoadCases, SP_Constraints
+// and MP_Constraints. These objects are all added to the AnalysisModel by a
 // ModelBuilder.
 //
-// Written: fmk 
+// Written: fmk
 // Created: Fri Sep 20 15:27:47: 1996
 // Revision: A
 //
@@ -59,7 +59,7 @@
 #define START_VERTEX_NUM 0
 
 
-static int 
+static int
 ApproxDOF(Domain& domain)
 {
   int nf = 0;
@@ -94,7 +94,7 @@ AnalysisModel::AnalysisModel(Domain& domain)
 
   theDOFs->setSize(ApproxDOF(domain));
   theFEs->setSize(domain.getNumElements());
-} 
+}
 
 
 
@@ -117,16 +117,16 @@ AnalysisModel::~AnalysisModel()
     delete theDOFiter;
 
   if (myGroupGraph != nullptr) {
-    delete myGroupGraph;    
-  }        
-  
+    delete myGroupGraph;
+  }
+
   if (myDOFGraph != nullptr) {
     delete myDOFGraph;
   }
 
   if (modalDamping != nullptr)
     delete modalDamping;
-}    
+}
 
 void
 AnalysisModel::setLinks(Domain &theDomain, ConstraintHandler &theHandler)
@@ -148,8 +148,8 @@ AnalysisModel::addFE_Element(FE_Element *theElement)
   int tag = theElement->getTag();
   TaggedObject *other = theFEs->getComponentPtr(tag);
   if (other != 0) {
-    opserr << "AnalysisModel::addFE_Element - element with tag " 
-           << tag << " already exists in model\n"; 
+    opserr << "AnalysisModel::addFE_Element - element with tag "
+           << tag << " already exists in model\n";
     return false;
   }
 
@@ -179,7 +179,7 @@ AnalysisModel::addDOF_Group(DOF_Group *theGroup)
   TaggedObject *other = theDOFs->getComponentPtr(tag);
   if (other != nullptr) {
     opserr << "AnalysisModel::addDOF_Group - group with tag "
-           << tag << " already exists in model\n"; 
+           << tag << " already exists in model\n";
     return false;
   }
 
@@ -194,33 +194,33 @@ AnalysisModel::addDOF_Group(DOF_Group *theGroup)
 
 
 void
-AnalysisModel::clearAll() 
+AnalysisModel::clearAll()
 {
   // if the graphs have been constructed delete them
   this->clearDOFGroupGraph();
 
-  this->clearDOFGraph(); 
+  this->clearDOFGraph();
 
   theFEs->clearAll();
   theDOFs->clearAll();
-  
+
   numFE_Ele =0;
   numDOF_Grp = 0;
   numEqn = 0;
 
   if (myHandler != nullptr)
     myHandler->clearAll();
-  
+
   if (modalDamping != nullptr)
     delete modalDamping;
   modalDamping = nullptr;
 
-  
+
   // for the nodes reset the DOF_Group pointers to 0
   Domain *theDomain = this->getDomainPtr();
   if (theDomain == nullptr)
     return;
-  
+
   NodeIter &theNod = theDomain->getNodes();
   Node *nodPtr;
   while ((nodPtr = theNod()) != nullptr)
@@ -228,7 +228,7 @@ AnalysisModel::clearAll()
 }
 
 void
-AnalysisModel::clearDOFGraph() 
+AnalysisModel::clearDOFGraph()
 {
   if (myDOFGraph != nullptr)
     delete myDOFGraph;
@@ -237,11 +237,11 @@ AnalysisModel::clearDOFGraph()
 }
 
 void
-AnalysisModel::clearDOFGroupGraph() 
+AnalysisModel::clearDOFGroupGraph()
 {
   if (myGroupGraph != nullptr)
-    delete myGroupGraph;    
-  
+    delete myGroupGraph;
+
   myGroupGraph = nullptr;
 }
 
@@ -281,7 +281,7 @@ AnalysisModel::getDOFs()
   return *theDOFiter;
 }
 
-void 
+void
 AnalysisModel::setNumEqn(int theNumEqn)
 {
   if (modalDamping != nullptr && (numEqn != theNumEqn)) {
@@ -292,7 +292,7 @@ AnalysisModel::setNumEqn(int theNumEqn)
   numEqn = theNumEqn;
 }
 
-int 
+int
 AnalysisModel::getNumEqn() const
 {
   return numEqn;
@@ -311,7 +311,7 @@ AnalysisModel::getDOFGraph()
     //
     // create a vertex for each dof
     //
-    
+
     DOF_Group *dofPtr =0;
     DOF_GrpIter &theDOFs = this->getDOFs();
     while ((dofPtr = theDOFs()) != 0) {
@@ -322,7 +322,7 @@ AnalysisModel::getDOFGraph()
         if (dofTag >= START_EQN_NUM) {
           Vertex *vertexPtr = myDOFGraph->getVertexPtr(dofTag);
           if (vertexPtr == 0) {
-            Vertex *vertexPtr = new Vertex(dofTag, dofTag);      
+            Vertex *vertexPtr = new Vertex(dofTag, dofTag);
             if (vertexPtr == 0) {
               opserr << "WARNING AnalysisModel::getDOFGraph";
               opserr << " - Not Enough Memory to create " << i+1 << "th Vertex\n";
@@ -336,33 +336,33 @@ AnalysisModel::getDOFGraph()
         }
       }
     }
-    
+
     // now add the edges, by looping over the FE_elements, getting their
     // IDs and adding edges between DOFs for equation numbers >= START_EQN_NUM
-    
+
     FE_Element *elePtr =0;
     FE_EleIter &eleIter = this->getFEs();
-    
+
     myDOFGraph->startAddEdge();
     while((elePtr = eleIter()) != 0) {
       const ID &id = elePtr->getID();
       const int size = id.Size();
       for (int i=0; i<size; i++) {
         int eqn1 = id(i);
-        
+
         // if eqnNum of DOF is a valid eqn number add an edge
         // to all other DOFs with valid eqn numbers.
         if (eqn1 >=START_EQN_NUM) {
           for (int j=i+1; j<size; j++) {
             int eqn2 = id(j);
-            if (eqn2 >=START_EQN_NUM)
+            if (eqn2 >= START_EQN_NUM && eqn1 != eqn2)
               myDOFGraph->addEdgeFast(eqn1-START_EQN_NUM+START_VERTEX_NUM,
                                   eqn2-START_EQN_NUM+START_VERTEX_NUM);
           }
         }
       }
     }
-  }    
+  }
 
   return *myDOFGraph;
 }
@@ -377,7 +377,7 @@ AnalysisModel::getDOFGroupGraph()
     // myGroupGraph = new Graph(numVertex);
     MapOfTaggedObjects *graphStorage = new MapOfTaggedObjects();
     myGroupGraph = new Graph(*graphStorage);
-        
+
 
     // now create the vertices with a reference equal to the DOF_Group number.
     // and a tag which ranges from 0 through numVertex-1
@@ -395,7 +395,7 @@ AnalysisModel::getDOFGroupGraph()
 
     // now add the edges, by looping over the Elements, getting their
     // IDs and adding edges between DOFs for equation numbers >= START_EQN_NUM
-    
+
     FE_Element *elePtr;
     FE_EleIter &eleIter = this->getFEs();
 
@@ -404,7 +404,7 @@ AnalysisModel::getDOFGroupGraph()
       int size = id.Size();
       for (int i=0; i<size; i++) {
         int dof1 = id(i);
-        for (int j=0; j<size; j++) 
+        for (int j=0; j<size; j++)
           if (i != j) {
             int dof2 = id(j);
             myGroupGraph->addEdge(dof1,dof2);
@@ -419,9 +419,9 @@ AnalysisModel::getDOFGroupGraph()
 
 
 
-void 
+void
 AnalysisModel::setResponse(const Vector &disp,
-                           const Vector &vel, 
+                           const Vector &vel,
                            const Vector &accel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
@@ -438,7 +438,7 @@ AnalysisModel::setResponse(const Vector &disp,
 void
 AnalysisModel::setStateGradient(
                     const Vector &u,
-                    const Vector &v, 
+                    const Vector &v,
                     const Vector &a,
                     int grad, int ngrad)
 {
@@ -450,11 +450,11 @@ AnalysisModel::setStateGradient(
   }
 }
 
-void 
+void
 AnalysisModel::getStateGradient(
-                    Vector &du, 
-                    Vector &dv, 
-                    Vector &da, 
+                    Vector &du,
+                    Vector &dv,
+                    Vector &da,
                     int grad)
 {
 
@@ -481,19 +481,19 @@ AnalysisModel::getStateGradient(
   }
 }
 
-int 
+int
 AnalysisModel::commitGradient(int gradNum, int numGrads)
 {
   // Loop through the FE_Elements and set unconditional sensitivities
   FE_Element *elePtr;
-  FE_EleIter &theEles = this->getFEs();    
+  FE_EleIter &theEles = this->getFEs();
   while ((elePtr = theEles()) != nullptr)
     elePtr->commitSensitivity(gradNum, numGrads);
 
   return 0;
 }
 
-void 
+void
 AnalysisModel::setDisp(const Vector &disp)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
@@ -501,30 +501,30 @@ AnalysisModel::setDisp(const Vector &disp)
 
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->setNodeDisp(disp);
-}        
-        
-void 
+}
+
+void
 AnalysisModel::setVel(const Vector &vel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
   DOF_Group   *dofPtr;
-  
+
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->setNodeVel(vel);
 }
-        
 
-void 
+
+void
 AnalysisModel::setAccel(const Vector &accel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
   DOF_Group   *dofPtr;
-  
-  while ((dofPtr = theDOFGrps()) != 0) 
-    dofPtr->setNodeAccel(accel);        
+
+  while ((dofPtr = theDOFGrps()) != 0)
+    dofPtr->setNodeAccel(accel);
 }
 
-void 
+void
 AnalysisModel::incrDisp(const Vector &disp)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
@@ -533,27 +533,27 @@ AnalysisModel::incrDisp(const Vector &disp)
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->incrNodeDisp(disp);
 }
-        
-void 
+
+void
 AnalysisModel::incrVel(const Vector &vel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
-  DOF_Group         *dofPtr;    
+  DOF_Group         *dofPtr;
   while ((dofPtr = theDOFGrps()) != nullptr)
     dofPtr->incrNodeVel(vel);
 }
 
 
 #if 0
-void 
+void
 AnalysisModel::incrAccel(const Vector &accel)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
     DOF_Group         *dofPtr;
-    
-    while ((dofPtr = theDOFGrps()) != 0) 
-      dofPtr->incrNodeAccel(accel);        
-}        
+
+    while ((dofPtr = theDOFGrps()) != 0)
+      dofPtr->incrNodeAccel(accel);
+}
 #endif
 
 
@@ -579,7 +579,7 @@ AnalysisModel::getState(Vector &U, Vector &Udot, Vector &Udotdot, int flag)
           U(loc) = disp(i);
         }
     }
-    
+
     const Vector &vel = dofPtr->getCommittedVel();
     for (int i=0; i < idSize; i++)  {
       int loc = id(i);
@@ -587,7 +587,7 @@ AnalysisModel::getState(Vector &U, Vector &Udot, Vector &Udotdot, int flag)
         Udot(loc) = vel(i);
       }
     }
-    
+
     const Vector &accel = dofPtr->getCommittedAccel();
     for (int i=0; i < idSize; i++)  {
       int loc = id(i);
@@ -601,7 +601,7 @@ AnalysisModel::getState(Vector &U, Vector &Udot, Vector &Udotdot, int flag)
 }
 
 
-int 
+int
 AnalysisModel::applyResidual(Integrator& assm, LinearSOE& soe)
 {
 
@@ -620,7 +620,7 @@ AnalysisModel::applyResidual(Integrator& assm, LinearSOE& soe)
   // loop through the FE_Elements and add the residual
   // same as IncrementalIntegrator::formElementResidual
   FE_Element *elePtr;
-  FE_EleIter &theEles2 = this->getFEs();    
+  FE_EleIter &theEles2 = this->getFEs();
   while ((elePtr = theEles2()) != nullptr) {
     if (soe.addB(elePtr->getResidual(&assm), elePtr->getID()) < 0) [[unlikely]] {
       res = -2;
@@ -632,7 +632,7 @@ AnalysisModel::applyResidual(Integrator& assm, LinearSOE& soe)
 
 
 
-int 
+int
 AnalysisModel::applyInertia(const Vector &v, Vector &res)
 {
   // int n = v.Size();
@@ -643,7 +643,7 @@ AnalysisModel::applyInertia(const Vector &v, Vector &res)
 
   // loop over the FE_Elements
   FE_Element *elePtr;
-  FE_EleIter &theEles = this->getFEs();    
+  FE_EleIter &theEles = this->getFEs();
   while((elePtr = theEles()) != nullptr) {
     const Vector &b = elePtr->getM_Force(v, 1.0);
     res.Assemble(b, elePtr->getID(), 1.0);
@@ -653,14 +653,14 @@ AnalysisModel::applyInertia(const Vector &v, Vector &res)
   DOF_Group *dofPtr;
   DOF_GrpIter &theDofs = this->getDOFs();
   while ((dofPtr = theDofs()) != nullptr) {
-    const Vector &a = dofPtr->getM_Force(v, 1.0);      
+    const Vector &a = dofPtr->getM_Force(v, 1.0);
     res.Assemble(a, dofPtr->getID(), 1.0);
   }
   return 0;
 }
 
 
-int 
+int
 AnalysisModel::applyInertia(const Vector &v, LinearSOE& soe, double fact)
 {
   assert(v.Size() == numEqn);
@@ -668,7 +668,7 @@ AnalysisModel::applyInertia(const Vector &v, LinearSOE& soe, double fact)
 
   // loop over the FE_Elements
   FE_Element *elePtr;
-  FE_EleIter &theEles = this->getFEs();    
+  FE_EleIter &theEles = this->getFEs();
   while((elePtr = theEles()) != nullptr) {
     const Vector &b = elePtr->getM_Force(v, 1.0);
     soe.addB(b, elePtr->getID(), fact);
@@ -678,14 +678,14 @@ AnalysisModel::applyInertia(const Vector &v, LinearSOE& soe, double fact)
   DOF_Group *dofPtr;
   DOF_GrpIter &theDofs = this->getDOFs();
   while ((dofPtr = theDofs()) != 0) {
-    const Vector &a = dofPtr->getM_Force(v, 1.0);      
+    const Vector &a = dofPtr->getM_Force(v, 1.0);
     soe.addB(a, dofPtr->getID(), fact);
   }
   return 0;
 }
 
 
-void 
+void
 AnalysisModel::setNumEigenvectors(int numEigenvectors)
 {
   Node *theNode;
@@ -695,18 +695,18 @@ AnalysisModel::setNumEigenvectors(int numEigenvectors)
 }
 
 
-void 
+void
 AnalysisModel::setEigenvalues(const Vector &eigenvalues)
 {
   myDomain->setEigenvalues(eigenvalues);
-}        
+}
 
 
 const Vector &
 AnalysisModel::getEigenvalues()
 {
   return myDomain->getEigenvalues();
-}        
+}
 
 
 
@@ -717,13 +717,13 @@ AnalysisModel::getModalDampingFactors()
 }
 
 
-bool 
+bool
 AnalysisModel::inclModalDampingMatrix()
 {
   return myDomain->inclModalDampingMatrix();
 }
 
-int 
+int
 AnalysisModel::setModalDamping(const Vector &modalDampingFactors)
 {
   if (modalDamping != nullptr)
@@ -733,18 +733,18 @@ AnalysisModel::setModalDamping(const Vector &modalDampingFactors)
   return 0;
 }
 
-void 
+void
 AnalysisModel::setEigenvector(int mode, const Vector &eigenvalue)
 {
   DOF_GrpIter &theDOFGrps = this->getDOFs();
   DOF_Group   *dofPtr;
-  
-  while ((dofPtr = theDOFGrps()) != nullptr) 
-    dofPtr->setEigenvector(mode, eigenvalue);        
-}        
+
+  while ((dofPtr = theDOFGrps()) != nullptr)
+    dofPtr->setEigenvector(mode, eigenvalue);
+}
 
 
-void 
+void
 AnalysisModel::applyLoadDomain(double time)
 {
   assert(myDomain != nullptr);
@@ -754,7 +754,7 @@ AnalysisModel::applyLoadDomain(double time)
 
 
 int
-AnalysisModel::applyLoadGradient() 
+AnalysisModel::applyLoadGradient()
 {
   // 1) Zero the unbalaced load
   Node *node;
@@ -877,7 +877,7 @@ AnalysisModel::getDomainPtr() const
   return myDomain;
 }
 
-void 
+void
 AnalysisModel::Print(OPS_Stream &s, int flag)
 {
   opserr << "{\n";
@@ -911,7 +911,7 @@ AnalysisModel::sendSelf(int cTag, Channel &theChannel)
 
 
 int
-AnalysisModel::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker) 
+AnalysisModel::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 {
   return 0;
 }

--- a/SRC/analysis/model/AnalysisModel.cpp
+++ b/SRC/analysis/model/AnalysisModel.cpp
@@ -355,7 +355,7 @@ AnalysisModel::getDOFGraph()
         if (eqn1 >=START_EQN_NUM) {
           for (int j=i+1; j<size; j++) {
             int eqn2 = id(j);
-            if (eqn2 >= START_EQN_NUM && eqn1 != eqn2)
+            if (eqn2 >= START_EQN_NUM)
               myDOFGraph->addEdgeFast(eqn1-START_EQN_NUM+START_VERTEX_NUM,
                                   eqn2-START_EQN_NUM+START_VERTEX_NUM);
           }

--- a/SRC/graph/graph/ArrayGraph.cpp
+++ b/SRC/graph/graph/ArrayGraph.cpp
@@ -17,8 +17,8 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-// 
-// Written: fmk 
+//
+// Written: fmk
 // Created: Sun Sept 15 11:47:47: 1996
 // Revision: A
 //
@@ -36,7 +36,7 @@
 
 ArrayGraph::ArrayGraph(int arraySize)
 :numVertex(0), numEdge(0), sizeVertices(arraySize), lastEmpty(0),
- theVertices(0), myIter(*this) 
+ theVertices(0), myIter(*this)
 {
     // we now try and get an array of size arraySize
     theVertices = new Vertex *[arraySize]{};
@@ -44,18 +44,18 @@ ArrayGraph::ArrayGraph(int arraySize)
 
 ArrayGraph::~ArrayGraph()
 {
-    // delete all the vertices, then delete theVertices array 
+    // delete all the vertices, then delete theVertices array
     if (theVertices != nullptr) {
-	for (int i=0; i<numVertex; i++)
-	    if (theVertices[i] != nullptr)
-		delete theVertices[i];
-	delete [] theVertices;
+  for (int i=0; i<numVertex; i++)
+      if (theVertices[i] != nullptr)
+    delete theVertices[i];
+  delete [] theVertices;
     }
 }
 
 
-// bool addVertex(int vertexTag, int vertexRef, 
-//		 int vertexWeight=0, int vertexColor = 0) 
+// bool addVertex(int vertexTag, int vertexRef,
+//     int vertexWeight=0, int vertexColor = 0)
 // Method to add a vertex to the graph. If the adjacency list
 // of the vertex is not empty the graph will first check to see all
 // vertices in the the the vertices adjacency list exist in the graph
@@ -66,63 +66,63 @@ ArrayGraph::~ArrayGraph()
 // delete()} on the old array. It now tries to add the vertex in the
 // array at location {\em vertexTag}. If this fails it adds at the first
 // empty location it comes to. Returns a 0 if successfull addition, a
-// $-1$ otherwise and a message to opserr explaining the problem. \\ 
+// $-1$ otherwise and a message to opserr explaining the problem. \\
 
 bool
 ArrayGraph::addVertex(Vertex *vertexPtr)
 {
     // check the vertex * and its adjacency list
     assert(vertexPtr != nullptr);
-    
+
     if (vertexPtr->getDegree() != 0) {
-	const ID &adjacency = vertexPtr->getAdjacency();
-	int size = adjacency.Size();
-	for (int i=0; i<size; i++) {
-	    Vertex *other = this->getVertexPtr(adjacency(i));
-	    if (other == 0) {
-		opserr << "WARNING ArrayGraph::addVertex";
-		opserr << " - vertex with adjacent vertex not in graph\n";
-		return false;
-	    }		
-	}
+  const ID &adjacency = vertexPtr->getAdjacency();
+  int size = adjacency.Size();
+  for (int i=0; i<size; i++) {
+      Vertex *other = this->getVertexPtr(adjacency(i));
+      if (other == 0) {
+    opserr << "WARNING ArrayGraph::addVertex";
+    opserr << " - vertex with adjacent vertex not in graph\n";
+    return false;
+      }
+  }
     }
 
     // check if we have room to place the vertex
     if (numVertex == sizeVertices) {
 
-	int newSize = sizeVertices*2;
-	Vertex **newVertices = new Vertex *[newSize];
+  int newSize = sizeVertices*2;
+  Vertex **newVertices = new Vertex *[newSize];
 
-	// copy the old and 0 the extra, then delete the old
-	for (int i=0; i<sizeVertices; i++)
-	    newVertices[i] = theVertices[i];
-	for (int j=sizeVertices; j<newSize; j++)
-	    newVertices[j] = nullptr;
+  // copy the old and 0 the extra, then delete the old
+  for (int i=0; i<sizeVertices; i++)
+      newVertices[i] = theVertices[i];
+  for (int j=sizeVertices; j<newSize; j++)
+      newVertices[j] = nullptr;
 
-	delete [] theVertices;
-	
-	theVertices = newVertices;
+  delete [] theVertices;
+
+  theVertices = newVertices;
         sizeVertices = newSize;
     }
-    
+
     // now see if we can add the Vertex into the array in its vertexTag location
     int vertexTag = vertexPtr->getTag();
-    if ((vertexTag >= 0) && (vertexTag < sizeVertices) && 
-	(theVertices[vertexTag] == 0)) {
+    if ((vertexTag >= 0) && (vertexTag < sizeVertices) &&
+  (theVertices[vertexTag] == 0)) {
 
-	theVertices[vertexTag]= vertexPtr;
-	numVertex++;
-	return false;
+  theVertices[vertexTag]= vertexPtr;
+  numVertex++;
+  return false;
 
     } else {
-	// we have to search through the array till we find an empty spot
-	for (int i=0; i<sizeVertices; i++) 
-	    if (theVertices[i] == nullptr) {
-		lastEmpty = i+1; // stores the lastEmpty place
-		theVertices[i] = vertexPtr;
-		numVertex++;
-		return true;
-	    }
+  // we have to search through the array till we find an empty spot
+  for (int i=0; i<sizeVertices; i++)
+      if (theVertices[i] == nullptr) {
+    lastEmpty = i+1; // stores the lastEmpty place
+    theVertices[i] = vertexPtr;
+    numVertex++;
+    return true;
+      }
     }
 
     // we should never get here
@@ -130,34 +130,34 @@ ArrayGraph::addVertex(Vertex *vertexPtr)
     return false;
 }
 
-// Vertex *getVertexPtr(int vertexTag);} 
-// A method which returns a pointer to the vertex whose tag is given by 
+// Vertex *getVertexPtr(int vertexTag);}
+// A method which returns a pointer to the vertex whose tag is given by
 // vertexTag. The method first looks at location {\em vertexTag} for the
 // vertex, otherwise it must search through the array until it finds the
 // vertex it is looking for. If no such vertex exists in the graph $0$ is
-// returned.\\ 
+// returned.\\
 
 Vertex *
-ArrayGraph::getVertexPtr(int vertexTag) 
+ArrayGraph::getVertexPtr(int vertexTag)
 {
     // check first to see if it's in a nice position
     if ((vertexTag >= 0) && (vertexTag < sizeVertices) &&
-	(theVertices[vertexTag] != 0) &&
-	(theVertices[vertexTag]->getTag() == vertexTag)) {
+  (theVertices[vertexTag] != 0) &&
+  (theVertices[vertexTag]->getTag() == vertexTag)) {
 
-	return theVertices[vertexTag];	
+  return theVertices[vertexTag];
     }
     // it's not nicely positioned, we have to search
-    // through theVertices until we find it 
-    else 
-	for (int i=0; i<sizeVertices; i++)
-	    if ((theVertices[i] != 0) && 
-		(theVertices[i]->getTag() == vertexTag)){
+    // through theVertices until we find it
+    else
+  for (int i=0; i<sizeVertices; i++)
+      if ((theVertices[i] != 0) &&
+    (theVertices[i]->getTag() == vertexTag)){
 
-		return theVertices[i];
-	    }
+    return theVertices[i];
+      }
 
-    // else the vertex is not there 
+    // else the vertex is not there
     return nullptr;
 }
 
@@ -166,34 +166,36 @@ ArrayGraph::getVertexPtr(int vertexTag)
 // the Graph. A check is first made to see if vertices with tags given by
 // {\em vertexTag} and {\em otherVertexTag} exist in the graph. If they
 // do not exist a $-1$ is returned, otherwise the method invokes {\em
-// addEdge()} on each of the corresponding vertices in the 
+// addEdge()} on each of the corresponding vertices in the
 // graph. Returns $0$ if sucessfull, a negative number if not.
 
-int 
+int
 ArrayGraph::addEdge(int vertexTag, int otherVertexTag)
 {
-    // get pointers to the vertices, if one does not exist return
+  // Self-loops are not stored in adjacency; do not inflate numEdge.
+  if (vertexTag == otherVertexTag)
+    return 0;
 
-    Vertex *vertex1 = this->getVertexPtr(vertexTag);
-    Vertex *vertex2 = this->getVertexPtr(otherVertexTag);
-    if ((vertex1 == 0) || (vertex2 == 0))
-	return -1;
+  Vertex *vertex1 = this->getVertexPtr(vertexTag);
+  Vertex *vertex2 = this->getVertexPtr(otherVertexTag);
+  if (vertex1 == nullptr || vertex2 == nullptr)
+    return -1;
 
-    // add an edge to each vertex
-    int result;
-    if ((result = vertex1->addEdge(otherVertexTag)) == 0)
-	if ((result = vertex2->addEdge(vertexTag)) == 0)
-	    numEdge++;
+  // add an edge to each vertex
+  int result;
+  if ((result = vertex1->addEdge(otherVertexTag)) == 0)
+    if ((result = vertex2->addEdge(vertexTag)) == 0)
+      numEdge++;
 
-    return result;
+  return result;
 }
 
-// VertexIter \&getVertices(void);} 
+// VertexIter \&getVertices(void);}
 // A method which first invokes {\em reset()} on the graphs ArrayVertexIter
 // and then returns a reference to this iter.\\
 
 VertexIter &
-ArrayGraph::getVertices(void) 
+ArrayGraph::getVertices(void)
 {
     // reset the iter and then return it
     myIter.reset();
@@ -201,40 +203,40 @@ ArrayGraph::getVertices(void)
 }
 
 
-int 
+int
 ArrayGraph::getNumVertex(void) const
 {
     return numVertex;
 }
 
 
-int 
+int
 ArrayGraph::getNumEdge(void) const
 {
     return numEdge;
 }
 
 
-int 
+int
 ArrayGraph::getArraySize(void) const
 {
     return sizeVertices;
 }
 
 
-void 
+void
 ArrayGraph::Print(OPS_Stream &s) const
 {
     s << numVertex << " " << numEdge << endln;
-    
+
     Vertex *vertexPtr;
-    
+
     // loop over the vertices and print each
-    
+
     for (int i=0; i<sizeVertices; i++) {
-	vertexPtr = theVertices[i];
-	if (vertexPtr != 0)
-	    vertexPtr->Print(s);
+  vertexPtr = theVertices[i];
+  if (vertexPtr != 0)
+      vertexPtr->Print(s);
     }
 }
 

--- a/SRC/graph/graph/DOF_Graph.cpp
+++ b/SRC/graph/graph/DOF_Graph.cpp
@@ -17,8 +17,8 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-// 
-// Written: fmk 
+//
+// Written: fmk
 // Created: Sun Sept 15 11:47:47: 1996
 // Revision: A
 //
@@ -41,13 +41,13 @@
 DOF_Graph::~DOF_Graph()
 {
 
-}    
+}
 
 // constructs the Graph
 // assumes eqn numbers are numbered continuously from START_EQN_NUM
 
 DOF_Graph::DOF_Graph(AnalysisModel &theModel)
-:Graph(theModel.getNumEqn()), 
+:Graph(theModel.getNumEqn()),
  myModel(theModel)
 {
 
@@ -55,23 +55,23 @@ DOF_Graph::DOF_Graph(AnalysisModel &theModel)
     int numVertex = myModel.getNumEqn();
 
     if (numVertex <= 0) {
-	opserr << "WARNING DOF_Graph::DOF_Graph";
-	opserr << "  - 0 equations?\n";
-	return;
-    }	
+  opserr << "WARNING DOF_Graph::DOF_Graph";
+  opserr << "  - 0 equations?\n";
+  return;
+    }
 
     // now create the vertices with a reference equal to the eqn number.
-    // and a tag which ranges from START_VERTEX_NUM through 
+    // and a tag which ranges from START_VERTEX_NUM through
 
     for (int i =0; i<numVertex; i++) {
-	Vertex *vertexPtr = new Vertex(i, i);
-	
-	if (vertexPtr == 0) {
-	    opserr << "WARNING DOF_Graph::DOF_Graph";
-	    opserr << " - Not Enough Memory to create " << i+1 << "th Vertex\n";
-	    return;
-	}
-	this->addVertex(vertexPtr,false);	
+  Vertex *vertexPtr = new Vertex(i, i);
+
+  if (vertexPtr == 0) {
+      opserr << "WARNING DOF_Graph::DOF_Graph";
+      opserr << " - Not Enough Memory to create " << i+1 << "th Vertex\n";
+      return;
+  }
+  this->addVertex(vertexPtr,false);
     }
     *****************************************************************************/
 
@@ -99,27 +99,26 @@ DOF_Graph::DOF_Graph(AnalysisModel &theModel)
   }
 
   // now add the edges, by looping over the FE_elements, getting their
-  // IDs and adding edges between DOFs for equation numbers >= START_EQN_NUM 
+  // IDs and adding edges between DOFs for equation numbers >= START_EQN_NUM
   FE_Element *elePtr =nullptr;
   FE_EleIter &eleIter = myModel.getFEs();
   int cnt = 0;
-  while((elePtr = eleIter()) != nullptr) {
+  while ((elePtr = eleIter()) != nullptr) {
     const ID &id = elePtr->getID();
     cnt++;
     int size = id.Size();
-    for (int i=0; i<size; i++) {
+    for (int i = 0; i < size; i++) {
       int eqn1 = id(i);
-	    
+
       // if eqnNum of DOF is a valid eqn number add an edge
       // to all other DOFs with valid eqn numbers.
-      
-      if (eqn1 >=START_EQN_NUM) {
-	for (int j=i+1; j<size; j++) {
-	  int eqn2 = id(j);
-	  if (eqn2 >=START_EQN_NUM)
-	    this->addEdge(eqn1-START_EQN_NUM+START_VERTEX_NUM,
-			  eqn2-START_EQN_NUM+START_VERTEX_NUM);
-	}
+      if (eqn1 >= START_EQN_NUM) {
+        for (int j = i + 1; j < size; j++) {
+          int eqn2 = id(j);
+          if (eqn2 >= START_EQN_NUM && eqn1 != eqn2)
+            this->addEdge(eqn1 - START_EQN_NUM + START_VERTEX_NUM,
+                          eqn2 - START_EQN_NUM + START_VERTEX_NUM);
+        }
       }
     }
   }

--- a/SRC/graph/graph/Graph.cpp
+++ b/SRC/graph/graph/Graph.cpp
@@ -18,7 +18,7 @@
 **                                                                    **
 ** ****************************************************************** */
 //
-// Written: fmk 
+// Written: fmk
 // Created: 11/96
 // Revision: A
 //
@@ -58,16 +58,16 @@ Graph::Graph(TaggedObjectStorage &theVerticesStorage)
 {
   TaggedObject *theObject;
   TaggedObjectIter &theObjects = theVerticesStorage.getComponents();
-  while ((theObject = theObjects()) != 0) 
+  while ((theObject = theObjects()) != 0)
     if (theObject->getTag() > nextFreeTag)
       nextFreeTag = theObject->getTag() + 1;
 
   theVerticesStorage.clearAll();
   theVertexIter = new VertexIter(myVertices);
 }
-    
 
-Graph::Graph(Graph &other) 
+
+Graph::Graph(Graph &other)
   :myVertices(0), theVertexIter(0), numEdge(0), nextFreeTag(START_VERTEX_NUM),
   vertices()
 {
@@ -104,21 +104,21 @@ Graph::~Graph()
 {
   // invoke delete on the Vertices
   myVertices->clearAll();
-  
+
   if (myVertices != 0)
     delete myVertices;
-    
+
   if (theVertexIter != 0)
     delete theVertexIter;
 }
 
 
-// bool addVertex(int vertexTag, int vertexRef, 
-//		 int vertexWeight=0, int vertexColor = 0) 
+// bool addVertex(int vertexTag, int vertexRef,
+//     int vertexWeight=0, int vertexColor = 0)
 // Method to add a vertex to the graph. If the adjacency list
 // of the vertex is not empty the graph will first check to see all
 // vertices in the the the vertices adjacency list exist in the graph
-// before the vertex is added. 
+// before the vertex is added.
 
 bool
 Graph::addVertex(Vertex *vertexPtr, bool checkAdjacency)
@@ -140,7 +140,7 @@ Graph::addVertex(Vertex *vertexPtr, bool checkAdjacency)
               opserr << "WARNING Graph::addVertex";
               opserr << " - vertex with adjacent vertex not in graph\n";
               return false;
-          }		
+          }
         }
     }
   }
@@ -163,17 +163,19 @@ Graph::addVertex(Vertex *vertexPtr, bool checkAdjacency)
 // the Graph. A check is first made to see if vertices with tags given by
 // {\em vertexTag} and {\em otherVertexTag} exist in the graph. If they
 // do not exist a $-1$ is returned, otherwise the method invokes {\em
-// addEdge()} on each of the corresponding vertices in the 
+// addEdge()} on each of the corresponding vertices in the
 // graph. Returns $0$ if sucessfull, a negative number if not.
 
-int 
+int
 Graph::addEdge(int vertexTag, int otherVertexTag)
 {
-  // get pointers to the vertices, if one does not exist return
+  // Self-loops are not stored in adjacency; do not inflate numEdge.
+  if (vertexTag == otherVertexTag)
+    return 0;
 
   Vertex *vertex1 = this->getVertexPtr(vertexTag);
   Vertex *vertex2 = this->getVertexPtr(otherVertexTag);
-  if ((vertex1 == 0) || (vertex2 == 0)) {
+  if (vertex1 == nullptr || vertex2 == nullptr) {
     opserr << "WARNING Graph::addEdge() - one or both of the vertices ";
     opserr << vertexTag << " " << otherVertexTag << " not in Graph\n";
     return -1;
@@ -219,18 +221,21 @@ Graph::startAddEdge()
   }
 }
 
-int 
+int
 Graph::addEdgeFast(int vertexTag, int otherVertexTag)
 {
-  // get pointers to the vertices, if one does not exist return
-  if ((int)vertices.size()<=vertexTag ||
-      (int)vertices.size()<=otherVertexTag) {
+  // See Graph::addEdge: self-loops must not inflate numEdge.
+  if (vertexTag == otherVertexTag)
+    return 0;
+
+  if ((int)vertices.size() <= vertexTag ||
+      (int)vertices.size() <= otherVertexTag) {
     opserr << "WARNING: the size of vertices is not correct\n";
     return -1;
   }
   Vertex *vertex1 = vertices[vertexTag];
   Vertex *vertex2 = vertices[otherVertexTag];
-  if ((vertex1 == 0) || (vertex2 == 0)) {
+  if (vertex1 == nullptr || vertex2 == nullptr) {
     opserr << "WARNING Graph::addEdge() - one or both of the vertices ";
     opserr << vertexTag << " " << otherVertexTag << " not in Graph\n";
     return -1;
@@ -273,7 +278,7 @@ Graph::getVertexPtr(int vertexTag)
 
 
 VertexIter &
-Graph::getVertices() 
+Graph::getVertices()
 {
   // reset the iter and then return it
   theVertexIter->reset();
@@ -281,20 +286,20 @@ Graph::getVertices()
 }
 
 
-int 
+int
 Graph::getNumVertex() const
 {
   return myVertices->getNumComponents();
 }
 
-int 
+int
 Graph::getNumEdge() const
 {
   return numEdge;
 }
 
-int 
-Graph::getFreeTag() 
+int
+Graph::getFreeTag()
 {
   return nextFreeTag;
 }
@@ -345,16 +350,16 @@ Graph::merge(Graph &other) {
     for (int i=0; i<adjacency.Size(); i++) {
       if (this->addEdge(vertexTag, adjacency(i)) < 0) {
         opserr << "Graph::merge - could not add an edge!\n";
-        return -2;	
+        return -2;
       }
     }
   }
-  
+
   return result;
 }
 
 
-void 
+void
 Graph::Print(OPS_Stream &s, int flag)
 {
   myVertices->Print(s, flag);
@@ -362,10 +367,10 @@ Graph::Print(OPS_Stream &s, int flag)
 
 
 
-int 
+int
 Graph::sendSelf(int commitTag, Channel &theChannel)
 {
-  // check not a datastore .. 
+  // check not a datastore ..
   if (theChannel.isDatastore() != 0) {
     opserr << "Graph::sendSelf() - does not at present send to a database\n";
     return -1;
@@ -405,9 +410,9 @@ Graph::sendSelf(int commitTag, Channel &theChannel)
       vertexData[vertexLocation++] = tmp;
       vertexData[vertexLocation++] = adjSize;
       for (int i=0; i<adjSize; i++)
-        vertexData[adjacencyLocation++] = adjacency(i);	  
+        vertexData[adjacencyLocation++] = adjacency(i);
       vertexWeights[weightLoc++] = vertexPtr->getWeight();
-    }  
+    }
 
     ID verticesData(vertexData, 5*numVertex + 2*numEdge, true);
     if (theChannel.sendID(0, commitTag, verticesData) < 0) {
@@ -436,8 +441,8 @@ Graph::sendSelf(int commitTag, Channel &theChannel)
 }
 
 
-int 
-Graph::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker) 
+int
+Graph::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 {
   // check not from a datastore
   if (theChannel.isDatastore() != 0) {
@@ -502,7 +507,7 @@ Graph::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
   for (int i=0; i<numVertex; i++) {
     Vertex *theVertex = new Vertex(0, 0);
     if (theVertex->recvSelf(commitTag, theChannel, theBroker) < 0) {
-      opserr << "Graph::recvSelf() - vertex failed to receive itself\n";      
+      opserr << "Graph::recvSelf() - vertex failed to receive itself\n";
       return -5;
     }
     this->addVertex(theVertex, false);

--- a/SRC/graph/graph/Vertex.cpp
+++ b/SRC/graph/graph/Vertex.cpp
@@ -18,7 +18,7 @@
 **                                                                    **
 ** ****************************************************************** */
 //
-// Written: fmk 
+// Written: fmk
 // Created: 11/96
 // Revision: A
 //
@@ -32,7 +32,7 @@
 #include <Vector.h>
 
 Vertex::Vertex(int tag, int ref, double weight, int color)
-:TaggedObject(tag), myRef(ref), myWeight(weight), myColor(color), 
+:TaggedObject(tag), myRef(ref), myWeight(weight), myColor(color),
  myDegree(0), myTmp(0)
  , myAdjacency(0, 8)
 {
@@ -40,8 +40,8 @@ Vertex::Vertex(int tag, int ref, double weight, int color)
 }
 
 
-Vertex::Vertex(const Vertex &other) 
-:TaggedObject(other.getTag()), myRef(other.myRef), myWeight(other.myWeight), myColor(other.myColor), 
+Vertex::Vertex(const Vertex &other)
+:TaggedObject(other.getTag()), myRef(other.myRef), myWeight(other.myWeight), myColor(other.myColor),
  myDegree(other.myDegree), myTmp(0)
  , myAdjacency(other.myAdjacency)
 {
@@ -51,63 +51,63 @@ Vertex::Vertex(const Vertex &other)
 Vertex::~Vertex()
 {
 
-}    
+}
 
-void 
-Vertex::setWeight(double newWeight) 
-{ 
+void
+Vertex::setWeight(double newWeight)
+{
   myWeight = newWeight;
 }
 
-void 
-Vertex::setColor(int newColor) 
+void
+Vertex::setColor(int newColor)
 {
   myColor = newColor;
 }
 
-void 
-Vertex::setTmp(int newTmp) 
+void
+Vertex::setTmp(int newTmp)
 {
   myTmp = newTmp;
 }
 
-int 
-Vertex::getRef() const 
+int
+Vertex::getRef() const
 {
   return myRef;
 }
 
 double
-Vertex::getWeight() const 
+Vertex::getWeight() const
 {
   return myWeight;
 }
 
-int 
+int
 Vertex::getColor() const
 {
   return myColor;
 }
 
-int 
+int
 Vertex::getTmp() const
 {
   return myTmp;
 }
 
-int 
+int
 Vertex::addEdge(int otherTag)
 {
-  // don't allow itself to be added
+  // Self-loops are rejected; return 1 ("already present") so Graph::addEdge
+  // does not treat this as a newly inserted edge and inflate numEdge.
   if (otherTag == this->getTag())
-    return 0;
+    return 1;
 
-  // check the otherVertex has not already been added
   return myAdjacency.insert(otherTag);
 }
 
 
-int 
+int
 Vertex::getDegree() const
 {
   return myDegree;
@@ -124,20 +124,20 @@ Vertex::Print(OPS_Stream &s, int flag)
 {
     s << this->getTag() << " " ;
     s << myRef << " ";
-    if (flag == 1) 
-	s << myWeight << " " ;
+    if (flag == 1)
+  s << myWeight << " " ;
     else if (flag == 2)
-	s << myColor << " " ;
+  s << myColor << " " ;
     else if (flag == 3)
-        s << myWeight << " " << myColor << " " ;    
+        s << myWeight << " " << myColor << " " ;
     else if (flag == 4)
       s << " weight: " << myWeight << " color: " << myColor << " tmp: " << myTmp << " " ;
 
-    s << "ADJACENCY: " << myAdjacency;    	
+    s << "ADJACENCY: " << myAdjacency;
 }
 
 
-int 
+int
 Vertex::sendSelf(int commitTag, Channel &theChannel)
 {
   // send the tag/ref/color/degree/tmp, an indication if weighted & size of adjacency
@@ -166,19 +166,19 @@ Vertex::sendSelf(int commitTag, Channel &theChannel)
       opserr << "Graph::rendSelf() - failed to receive the weight\n";
       return -2;
     }
-  }    
+  }
 
   // finally send the adjacency
   if (theChannel.sendID(0, commitTag, myAdjacency) < 0) {
     opserr << "Graph::sendSelf() - failed to receive the adjacency data\n";
     return -1;
-  }  
+  }
 
   return 0;
 }
 
 
-int 
+int
 Vertex::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 {
   // recv the tag/ref/color/degree/tmp, an indication if weighted & size of adjacency
@@ -201,7 +201,7 @@ Vertex::recvSelf(int commitTag, Channel &theChannel, FEM_ObjectBroker &theBroker
       return -2;
     }
     myWeight = vectData(0);
-  }    
+  }
 
   // resize the adjacency & receive it
   //  myAdjacency[idData(6)-1] = 0;


### PR DESCRIPTION
`Vertex::addEdge` rejects self-loops but still returned `0` (i.e. “added”), so `Graph` increased `numEdge` without growing either adjacency list. That created a mismatch between the expected number of nonzeros from `nnz = numVertices + 2*numEdges` and the count from looping over the adjacency lists. Under the Transformation constraint handler this shows up when an element’s condensed IDs repeat an equation and the DOF graph asks for `addEdge(i,i)`.