### PR TITLE
Fix R degradation in SteelMPF when strain history starts at zero

### DIFF
--- a/SRC/material/uniaxial/steel/SteelMPF.cpp
+++ b/SRC/material/uniaxial/steel/SteelMPF.cpp
@@ -1,24 +1,24 @@
-// Code written/implemented by:	Kristijan Kolozvari (kkolozvari@fullerton.edu)
-//								California State University, Fullerton 
-//								Kutay Orakcal
-//								Bogazici University, Istanbul, Turkey
-//								John Wallace
-//								University of California, Los Angeles
+// Code written/implemented by:  Kristijan Kolozvari (kkolozvari@fullerton.edu)
+//                California State University, Fullerton
+//                Kutay Orakcal
+//                Bogazici University, Istanbul, Turkey
+//                John Wallace
+//                University of California, Los Angeles
 //
 // Created: 10/2015
 //
-// Description: This file contains the class implementation for uniaxialMaterial 
-// SteelMPF, which represents the well-known uniaxial constitutive nonlinear 
-// hysteretic material model for steel proposed by Menegotto and Pinto (1973), 
-// and extended by Filippou et al. (1983) to include isotropic strain hardening 
+// Description: This file contains the class implementation for uniaxialMaterial
+// SteelMPF, which represents the well-known uniaxial constitutive nonlinear
+// hysteretic material model for steel proposed by Menegotto and Pinto (1973),
+// and extended by Filippou et al. (1983) to include isotropic strain hardening
 // effects.
 //
 // References:
-// 1) Menegotto, M., and Pinto, P.E. (1973). Method of analysis of cyclically 
-// loaded RC plane frames including changes in geometry and non-elastic behavior 
-// of elements under normal force and bending. Preliminary Report IABSE, vol 13. 
-// 2) Filippou F.C., Popov, E.P., and Bertero, V.V. (1983). "Effects of Bond 
-// Deterioration on Hysteretic Behavior of Reinforced Concrete Joints". Report 
+// 1) Menegotto, M., and Pinto, P.E. (1973). Method of analysis of cyclically
+// loaded RC plane frames including changes in geometry and non-elastic behavior
+// of elements under normal force and bending. Preliminary Report IABSE, vol 13.
+// 2) Filippou F.C., Popov, E.P., and Bertero, V.V. (1983). "Effects of Bond
+// Deterioration on Hysteretic Behavior of Reinforced Concrete Joints". Report
 // EERC 83-19, Earthquake Engineering Research Center, University of California, Berkeley.
 //
 // Source: /usr/local/cvs/OpenSees/SRC/material/uniaxial/SteelMPF.cpp
@@ -35,261 +35,261 @@
 #include <float.h>
 
 #include <elementAPI.h>
-#define OPS_Export 
+#define OPS_Export
 
 // Read input parameters and build the material
 OPS_Export void * OPS_ADD_RUNTIME_VPV(OPS_SteelMPF)
 {
-	// Pointer to a uniaxial material that will be returned                       
-	UniaxialMaterial *theMaterial = 0;
+  // Pointer to a uniaxial material that will be returned
+  UniaxialMaterial *theMaterial = 0;
 
-	int numArgs = OPS_GetNumRemainingInputArgs();
+  int numArgs = OPS_GetNumRemainingInputArgs();
 
-	// Parse the script for material parameters
-	if (numArgs != 9 && numArgs != 13) {
-		opserr << "Incorrect # args, Want: uniaxialMaterial SteelMPF tag? sigyieldp? sigyieldn? E0? bp? bn? R0? cR1? cR2? <a1? a2? a3? a4?>";
-		return 0;
-	}
+  // Parse the script for material parameters
+  if (numArgs != 9 && numArgs != 13) {
+    opserr << "Incorrect # args, Want: uniaxialMaterial SteelMPF tag? sigyieldp? sigyieldn? E0? bp? bn? R0? cR1? cR2? <a1? a2? a3? a4?>";
+    return 0;
+  }
 
-	int iData[1];
-	double dData[12];
-	dData[8] = 0.0;		// set a3 to constructor default
-	dData[9] = 1.0;		// set a4 to constructor default
-	dData[10] = 0.0;	// set a5 to constructor default
-	dData[11] = 1.0;    // set a6 to constructor default
+  int iData[1];
+  double dData[12];
+  dData[8] = 0.0;    // set a3 to constructor default
+  dData[9] = 1.0;    // set a4 to constructor default
+  dData[10] = 0.0;  // set a5 to constructor default
+  dData[11] = 1.0;    // set a6 to constructor default
 
-	int numData = 1;
-	if (OPS_GetIntInput(&numData, iData) != 0) {
-		opserr << "WARNING invalid uniaxialMaterial SteelMPF tag" << endln;
-		return 0;
-	}
+  int numData = 1;
+  if (OPS_GetIntInput(&numData, iData) != 0) {
+    opserr << "WARNING invalid uniaxialMaterial SteelMPF tag" << endln;
+    return 0;
+  }
 
-	numData = numArgs-1;
-	if (OPS_GetDoubleInput(&numData, dData) != 0) {
-		opserr << "Invalid data for uniaxialMaterial SteelMPF " << dData[0] << endln;
-		return 0;
-	}
+  numData = numArgs-1;
+  if (OPS_GetDoubleInput(&numData, dData) != 0) {
+    opserr << "Invalid data for uniaxialMaterial SteelMPF " << dData[0] << endln;
+    return 0;
+  }
 
-	theMaterial = new SteelMPF(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4], 
-		dData[5], dData[6], dData[7], dData[8], dData[9], dData[10], dData[11]);
+  theMaterial = new SteelMPF(iData[0], dData[0], dData[1], dData[2], dData[3], dData[4],
+    dData[5], dData[6], dData[7], dData[8], dData[9], dData[10], dData[11]);
 
-	return theMaterial;
+  return theMaterial;
 }
 
 // Default Constructor
 SteelMPF::SteelMPF
-	(int tag, double FYp, double FYn, double E, double Bp, double Bn, double Rr, double A1, double A2):
+  (int tag, double FYp, double FYn, double E, double Bp, double Bn, double Rr, double A1, double A2):
 UniaxialMaterial(tag,MAT_TAG_SteelMPF),
-	sigyieldp(FYp), sigyieldn(FYn), E0(E), bp(Bp), bn(Bn), R0(Rr), aa1(A1), a2(A2), 
-	a3(0.0), a4(1.0), a5(0.0), a6(1.0) // default values for strain hardening
+  sigyieldp(FYp), sigyieldn(FYn), E0(E), bp(Bp), bn(Bn), R0(Rr), aa1(A1), a2(A2),
+  a3(0.0), a4(1.0), a5(0.0), a6(1.0) // default values for strain hardening
 
 {
-	// Sets all history and state variables to initial values
+  // Sets all history and state variables to initial values
 
-	// TRIAL History variables
-	inc = 0;
+  // TRIAL History variables
+  inc = 0;
 
-	Rptwoprev = 0.0;
-	Rntwoprev = 0.0;
+  Rptwoprev = 0.0;
+  Rntwoprev = 0.0;
 
-	outp = 0;
-	outn = 0;
+  outp = 0;
+  outn = 0;
 
-	erp = 0.0;
-	sigrp = 0.0;
+  erp = 0.0;
+  sigrp = 0.0;
 
-	ern = 0.0;
-	sigrn = 0.0;
+  ern = 0.0;
+  sigrn = 0.0;
 
-	erpmaxmax = 0.0;
-	ernmaxmax = 0.0;
+  erpmaxmax = 0.0;
+  ernmaxmax = 0.0;
 
-	e0p = 0.0;
-	sig0p = 0.0;
+  e0p = 0.0;
+  sig0p = 0.0;
 
-	e0n = 0.0;
-	sig0n = 0.0;
+  e0n = 0.0;
+  sig0n = 0.0;
 
-	erntwoprev = 0.0;
-	sigrntwoprev = 0.0;
-	e0ntwoprev = 0.0;
-	sig0ntwoprev = 0.0;
+  erntwoprev = 0.0;
+  sigrntwoprev = 0.0;
+  e0ntwoprev = 0.0;
+  sig0ntwoprev = 0.0;
 
-	erptwoprev = 0.0;
-	sigrptwoprev = 0.0;
-	e0ptwoprev = 0.0;
-	sig0ptwoprev = 0.0;
+  erptwoprev = 0.0;
+  sigrptwoprev = 0.0;
+  e0ptwoprev = 0.0;
+  sig0ptwoprev = 0.0;
 
-	Rp = 0.0;
-	Rn = 0.0;
+  Rp = 0.0;
+  Rn = 0.0;
 
-	nloop = 0;
+  nloop = 0;
 
-	// CONVERGED History variables
-	incold = 0;
+  // CONVERGED History variables
+  incold = 0;
 
-	Rptwoprevold = 0.0;
-	Rntwoprevold = 0.0;
+  Rptwoprevold = 0.0;
+  Rntwoprevold = 0.0;
 
-	outpold = 0;
-	outnold = 0;
+  outpold = 0;
+  outnold = 0;
 
-	erpold = 0.0;
-	sigrpold = 0.0;
+  erpold = 0.0;
+  sigrpold = 0.0;
 
-	ernold = 0.0;
-	sigrnold = 0.0;
+  ernold = 0.0;
+  sigrnold = 0.0;
 
-	erpmaxmaxold = 0.0;
-	ernmaxmaxold = 0.0;
+  erpmaxmaxold = 0.0;
+  ernmaxmaxold = 0.0;
 
-	e0pold = 0.0;
-	sig0pold = 0.0;
+  e0pold = 0.0;
+  sig0pold = 0.0;
 
-	e0nold = 0.0;
-	sig0nold = 0.0;
+  e0nold = 0.0;
+  sig0nold = 0.0;
 
-	erntwoprevold = 0.0;
-	sigrntwoprevold = 0.0;
-	e0ntwoprevold = 0.0;
-	sig0ntwoprevold = 0.0;
+  erntwoprevold = 0.0;
+  sigrntwoprevold = 0.0;
+  e0ntwoprevold = 0.0;
+  sig0ntwoprevold = 0.0;
 
-	erptwoprevold = 0.0;
-	sigrptwoprevold = 0.0;
-	e0ptwoprevold = 0.0;
-	sig0ptwoprevold = 0.0;
+  erptwoprevold = 0.0;
+  sigrptwoprevold = 0.0;
+  e0ptwoprevold = 0.0;
+  sig0ptwoprevold = 0.0;
 
-	Rpold = R0;
-	Rnold = R0;
+  Rpold = R0;
+  Rnold = R0;
 
-	nloopold = 0;
+  nloopold = 0;
 
-	a1 = aa1*R0;
+  a1 = aa1*R0;
 
-	// TRIAL State variables
-	def = 0.0;
-	F = 0.0;
-	stif = E0;	
+  // TRIAL State variables
+  def = 0.0;
+  F = 0.0;
+  stif = E0;
 
-	// CONVERGED State variables
-	defold = 0.0;
-	Fold = 0.0;
-	stifold = E0; 
+  // CONVERGED State variables
+  defold = 0.0;
+  Fold = 0.0;
+  stifold = E0;
 
-	// Yield Strain
-	eyieldp = sigyieldp/E0; 
-	eyieldn = sigyieldn/E0;
+  // Yield Strain
+  eyieldp = sigyieldp/E0;
+  eyieldn = sigyieldn/E0;
 
 }
 
 // Constructor with optional strain hardening parameters a3, a4, a5 and a6
 SteelMPF::SteelMPF
-	(int tag, double FYp, double FYn, double E, double Bp, double Bn, double Rr, double A1, double A2, double A3, double A4, double A5, double A6) :
+  (int tag, double FYp, double FYn, double E, double Bp, double Bn, double Rr, double A1, double A2, double A3, double A4, double A5, double A6) :
 UniaxialMaterial(tag, MAT_TAG_SteelMPF),
-	sigyieldp(FYp), sigyieldn(FYn), E0(E), bp(Bp), bn(Bn), R0(Rr), aa1(A1), a2(A2), a3(A3), a4(A4), a5(A5), a6(A6)
+  sigyieldp(FYp), sigyieldn(FYn), E0(E), bp(Bp), bn(Bn), R0(Rr), aa1(A1), a2(A2), a3(A3), a4(A4), a5(A5), a6(A6)
 
 {
-	// Sets all history and state variables to initial values
+  // Sets all history and state variables to initial values
 
-	// TRIAL History variables
-	inc = 0;
+  // TRIAL History variables
+  inc = 0;
 
-	Rptwoprev = 0.0;
-	Rntwoprev = 0.0;
+  Rptwoprev = 0.0;
+  Rntwoprev = 0.0;
 
-	outp = 0;
-	outn = 0;
+  outp = 0;
+  outn = 0;
 
-	erp = 0.0;
-	sigrp = 0.0;
+  erp = 0.0;
+  sigrp = 0.0;
 
-	ern = 0.0;
-	sigrn = 0.0;
+  ern = 0.0;
+  sigrn = 0.0;
 
-	erpmaxmax = 0.0;
-	ernmaxmax = 0.0;
+  erpmaxmax = 0.0;
+  ernmaxmax = 0.0;
 
-	e0p = 0.0;
-	sig0p = 0.0;
+  e0p = 0.0;
+  sig0p = 0.0;
 
-	e0n = 0.0;
-	sig0n = 0.0;
+  e0n = 0.0;
+  sig0n = 0.0;
 
-	erntwoprev = 0.0;
-	sigrntwoprev = 0.0;
-	e0ntwoprev = 0.0;
-	sig0ntwoprev = 0.0;
+  erntwoprev = 0.0;
+  sigrntwoprev = 0.0;
+  e0ntwoprev = 0.0;
+  sig0ntwoprev = 0.0;
 
-	erptwoprev = 0.0;
-	sigrptwoprev = 0.0;
-	e0ptwoprev = 0.0;
-	sig0ptwoprev = 0.0;
+  erptwoprev = 0.0;
+  sigrptwoprev = 0.0;
+  e0ptwoprev = 0.0;
+  sig0ptwoprev = 0.0;
 
-	Rp = 0.0;
-	Rn = 0.0;
+  Rp = 0.0;
+  Rn = 0.0;
 
-	nloop = 0;
+  nloop = 0;
 
-	// CONVERGED History variables
-	incold = 0;
+  // CONVERGED History variables
+  incold = 0;
 
-	Rptwoprevold = 0.0;
-	Rntwoprevold = 0.0;
+  Rptwoprevold = 0.0;
+  Rntwoprevold = 0.0;
 
-	outpold = 0;
-	outnold = 0;
+  outpold = 0;
+  outnold = 0;
 
-	erpold = 0.0;
-	sigrpold = 0.0;
+  erpold = 0.0;
+  sigrpold = 0.0;
 
-	ernold = 0.0;
-	sigrnold = 0.0;
+  ernold = 0.0;
+  sigrnold = 0.0;
 
-	erpmaxmaxold = 0.0;
-	ernmaxmaxold = 0.0;
+  erpmaxmaxold = 0.0;
+  ernmaxmaxold = 0.0;
 
-	e0pold = 0.0;
-	sig0pold = 0.0;
+  e0pold = 0.0;
+  sig0pold = 0.0;
 
-	e0nold = 0.0;
-	sig0nold = 0.0;
+  e0nold = 0.0;
+  sig0nold = 0.0;
 
-	erntwoprevold = 0.0;
-	sigrntwoprevold = 0.0;
-	e0ntwoprevold = 0.0;
-	sig0ntwoprevold = 0.0;
+  erntwoprevold = 0.0;
+  sigrntwoprevold = 0.0;
+  e0ntwoprevold = 0.0;
+  sig0ntwoprevold = 0.0;
 
-	erptwoprevold = 0.0;
-	sigrptwoprevold = 0.0;
-	e0ptwoprevold = 0.0;
-	sig0ptwoprevold = 0.0;
+  erptwoprevold = 0.0;
+  sigrptwoprevold = 0.0;
+  e0ptwoprevold = 0.0;
+  sig0ptwoprevold = 0.0;
 
-	Rpold = R0;
-	Rnold = R0;
+  Rpold = R0;
+  Rnold = R0;
 
-	nloopold = 0;
+  nloopold = 0;
 
-	a1 = aa1*R0;
+  a1 = aa1*R0;
 
-	// TRIAL State variables
-	def = 0.0;
-	F = 0.0;
-	stif = E0;
+  // TRIAL State variables
+  def = 0.0;
+  F = 0.0;
+  stif = E0;
 
-	// CONVERGED State variables
-	defold = 0.0;
-	Fold = 0.0;
-	stifold = E0; 
+  // CONVERGED State variables
+  defold = 0.0;
+  Fold = 0.0;
+  stifold = E0;
 
-	// Yield Strain
-	eyieldp = sigyieldp/E0; 
-	eyieldn = sigyieldn/E0;
+  // Yield Strain
+  eyieldp = sigyieldp/E0;
+  eyieldn = sigyieldn/E0;
 
 }
 
 // blank constructor
 SteelMPF::SteelMPF() :UniaxialMaterial(0, MAT_TAG_SteelMPF),
-	sigyieldp(0.0), sigyieldn(0.0), E0(0.0), bp(0.0), bn(0.0), R0(0.0), aa1(0.0), a2(0.0), a3(0.0), a4(0.0), a5(0.0), a6(0.0)
+  sigyieldp(0.0), sigyieldn(0.0), E0(0.0), bp(0.0), bn(0.0), R0(0.0), aa1(0.0), a2(0.0), a3(0.0), a4(0.0), a5(0.0), a6(0.0)
 {
 
 }
@@ -302,1015 +302,1025 @@ SteelMPF::~SteelMPF ()
 
 int SteelMPF::setTrialStrain(double strain, double strainRate)
 {
-	// Reset history variables to last converged state
-	inc = incold;
+  // Reset history variables to last converged state
+  inc = incold;
 
-	Rptwoprev = Rptwoprevold;
-	Rntwoprev = Rntwoprevold;
+  Rptwoprev = Rptwoprevold;
+  Rntwoprev = Rntwoprevold;
 
-	outp = outpold;
-	outn = outnold;
+  outp = outpold;
+  outn = outnold;
 
-	erp = erpold;
-	sigrp = sigrpold;
+  erp = erpold;
+  sigrp = sigrpold;
 
-	ern = ernold;
-	sigrn = sigrnold;
+  ern = ernold;
+  sigrn = sigrnold;
 
-	erpmaxmax = erpmaxmaxold;
-	ernmaxmax = ernmaxmaxold;
+  erpmaxmax = erpmaxmaxold;
+  ernmaxmax = ernmaxmaxold;
 
-	e0p = e0pold;
-	sig0p = sig0pold;
+  e0p = e0pold;
+  sig0p = sig0pold;
 
-	e0n = e0nold;
-	sig0n = sig0nold;
+  e0n = e0nold;
+  sig0n = sig0nold;
 
-	erntwoprev = erntwoprevold;
-	sigrntwoprev = sigrntwoprevold;
-	e0ntwoprev = e0ntwoprevold;
-	sig0ntwoprev = sig0ntwoprevold;
+  erntwoprev = erntwoprevold;
+  sigrntwoprev = sigrntwoprevold;
+  e0ntwoprev = e0ntwoprevold;
+  sig0ntwoprev = sig0ntwoprevold;
 
-	erptwoprev = erptwoprevold;
-	sigrptwoprev = sigrptwoprevold;
-	e0ptwoprev = e0ptwoprevold;
-	sig0ptwoprev = sig0ptwoprevold;
+  erptwoprev = erptwoprevold;
+  sigrptwoprev = sigrptwoprevold;
+  e0ptwoprev = e0ptwoprevold;
+  sig0ptwoprev = sig0ptwoprevold;
 
-	Rp = Rpold;
-	Rn = Rnold;
+  Rp = Rpold;
+  Rn = Rnold;
 
-	nloop = nloopold;
+  nloop = nloopold;
 
-	// Set trial strain
-	def = strain;
+  // Set trial strain
+  def = strain;
 
-	// Calculate the trial state given the trial strain
-	this->determineTrialState(def);
+  // Calculate the trial state given the trial strain
+  this->determineTrialState(def);
 
-	return 0;
+  return 0;
 }
 
 
 int SteelMPF::setTrial (double strain, double &stress, double &tangent, double strainRate)
 {
-	// Reset history variables to last converged state
-	inc = incold;
+  // Reset history variables to last converged state
+  inc = incold;
 
-	Rptwoprev = Rptwoprevold;
-	Rntwoprev = Rntwoprevold;
+  Rptwoprev = Rptwoprevold;
+  Rntwoprev = Rntwoprevold;
 
-	outp = outpold;
-	outn = outnold;
+  outp = outpold;
+  outn = outnold;
 
-	erp = erpold;
-	sigrp = sigrpold;
+  erp = erpold;
+  sigrp = sigrpold;
 
-	ern = ernold;
-	sigrn = sigrnold;
+  ern = ernold;
+  sigrn = sigrnold;
 
-	erpmaxmax = erpmaxmaxold;
-	ernmaxmax = ernmaxmaxold;
+  erpmaxmax = erpmaxmaxold;
+  ernmaxmax = ernmaxmaxold;
 
-	e0p = e0pold;
-	sig0p = sig0pold;
+  e0p = e0pold;
+  sig0p = sig0pold;
 
-	e0n = e0nold;
-	sig0n = sig0nold;
+  e0n = e0nold;
+  sig0n = sig0nold;
 
-	erntwoprev = erntwoprevold;
-	sigrntwoprev = sigrntwoprevold;
-	e0ntwoprev = e0ntwoprevold;
-	sig0ntwoprev = sig0ntwoprevold;
+  erntwoprev = erntwoprevold;
+  sigrntwoprev = sigrntwoprevold;
+  e0ntwoprev = e0ntwoprevold;
+  sig0ntwoprev = sig0ntwoprevold;
 
-	erptwoprev = erptwoprevold;
-	sigrptwoprev = sigrptwoprevold;
-	e0ptwoprev = e0ptwoprevold;
-	sig0ptwoprev = sig0ptwoprevold;
+  erptwoprev = erptwoprevold;
+  sigrptwoprev = sigrptwoprevold;
+  e0ptwoprev = e0ptwoprevold;
+  sig0ptwoprev = sig0ptwoprevold;
 
-	Rp = Rpold;
-	Rn = Rnold;
+  Rp = Rpold;
+  Rn = Rnold;
 
-	nloop = nloopold;
+  nloop = nloopold;
 
-	// Set trial strain
-	def = strain;
+  // Set trial strain
+  def = strain;
 
-	// Calculate the trial state given the trial strain
-	this->determineTrialState(def);
+  // Calculate the trial state given the trial strain
+  this->determineTrialState(def);
 
-	stress = F; 
-	tangent = stif;
+  stress = F;
+  tangent = stif;
 
-	return 0;
+  return 0;
 }
 
 // Calculate trial stress and stiffness
 void SteelMPF::determineTrialState(double def)
 {
 
-	double e = def;
-	double eold = defold;
-	double sigold = Fold;
-
-	// Determine initial loading condition
-	if (incold == 0) {
-
-		Rptwoprev = R0;
-		Rntwoprev = R0;
-		outp = 1;
-		outn = 1;
+  double e = def;
+  double eold = defold;
+  double sigold = Fold;
 
-		if (e < 0.0) {
-			inc = -1;
-		} else {
-			inc = 1;
-		}
+  // Determine initial loading condition
+  if (incold == 0) {
 
-		erp=0.0;
-		sigrp=0.0;
-		ern=0.0;
-		sigrn=0.0;
+    static constexpr double strainTol = 1.0e-14;
 
-		erptwoprev=0.0;
-		sigrptwoprev=0.0;
-		erntwoprev=0.0;
-		sigrntwoprev=0.0;
+    Rptwoprev = R0;
+    Rntwoprev = R0;
+    outp = 1;
+    outn = 1;
 
-		erpmaxmax=0.0;
-		ernmaxmax=0.0;
+    if (e < -strainTol) {
+      inc = -1;
+    } else if (e > strainTol) {
+      inc = 1;
+    } else {
+      inc = 0;
+    }
 
-		e0p=eyieldp;
-		sig0p=sigyieldp;
-		e0ptwoprev=e0p;
-		sig0ptwoprev=sig0p;
+    erp=0.0;
+    sigrp=0.0;
+    ern=0.0;
+    sigrn=0.0;
 
-		e0n=-eyieldn;
-		sig0n=-sigyieldn;
-		e0ntwoprev=e0n;
-		sig0ntwoprev=sig0n;
+    erptwoprev=0.0;
+    sigrptwoprev=0.0;
+    erntwoprev=0.0;
+    sigrntwoprev=0.0;
 
-		if (e==0.0) {
-			nloop=0;
-		} else {
-			nloop=1;
-		}
+    erpmaxmax=0.0;
+    ernmaxmax=0.0;
 
-		Rp = R0;
-		Rn = R0;
+    e0p=eyieldp;
+    sig0p=sigyieldp;
+    e0ptwoprev=e0p;
+    sig0ptwoprev=sig0p;
 
-		if (inc==1) {
+    e0n=-eyieldn;
+    sig0n=-sigyieldn;
+    e0ntwoprev=e0n;
+    sig0ntwoprev=sig0n;
 
-			e0p=eyieldp;
-			sig0p=sigyieldp;
-			e0ptwoprev=e0p;
-			sig0ptwoprev=sig0p;
+    Rp = R0;
+    Rn = R0;
 
-			double estp=(e-erp)/(e0p-erp);
-			double sigstp=bp*estp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*estp; 
-			double sig=sigrp+sigstp*(sig0p-sigrp);
-			double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
+    if (inc == 0) {
 
-			F = sig;
-			stif = Et;
+      F = 0.0;
+      stif = E0;
+      nloop = 0;
 
-		} else {
+    } else {
 
-			e0n=-eyieldn;
-			sig0n=-sigyieldn;
-			e0ntwoprev=e0n;
-			sig0ntwoprev=sig0n;
+      nloop = 1;
 
-			double estn=(e-ern)/(e0n-ern);
-			double sigstn=bn*estn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*estn;
-			double sig=sigrn+sigstn*(sig0n-sigrn);
-			double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
+      if (inc == 1) {
 
-			F = sig;
-			stif = Et;
+        e0p=eyieldp;
+        sig0p=sigyieldp;
+        e0ptwoprev=e0p;
+        sig0ptwoprev=sig0p;
 
-		}
+        double estp=(e-erp)/(e0p-erp);
+        double sigstp=bp*estp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*estp;
+        double sig=sigrp+sigstp*(sig0p-sigrp);
+        double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
 
-	}
+        F = sig;
+        stif = Et;
 
-	else {
+      } else {
 
-		// Cyclic Stress - Strain model for Steel derived from Menegotto - Pinto Equation
+        e0n=-eyieldn;
+        sig0n=-sigyieldn;
+        e0ntwoprev=e0n;
+        sig0ntwoprev=sig0n;
 
-		outp=outpold;
-		outn=outnold;
-		Rptwoprev=Rptwoprevold;
-		Rntwoprev=Rntwoprevold;
+        double estn=(e-ern)/(e0n-ern);
+        double sigstn=bn*estn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*estn;
+        double sig=sigrn+sigstn*(sig0n-sigrn);
+        double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
 
-		if (def > defold) {
-			inc = 1;
-		} else if (def < defold) {
-			inc = -1;
-		} else {
-			inc = incold;
-		}
+        F = sig;
+        stif = Et;
 
-		erp=erpold;
-		sigrp=sigrpold;
+      }
 
-		ern=ernold;
-		sigrn=sigrnold;
+    }
 
-		erpmaxmax=erpmaxmaxold;
-		ernmaxmax=ernmaxmaxold;
+  }
 
-		e0p=e0pold;
-		sig0p=sig0pold;
+  else {
 
-		e0n=e0nold;
-		sig0n=sig0nold;
+    // Cyclic Stress - Strain model for Steel derived from Menegotto - Pinto Equation
 
-		erntwoprev=erntwoprevold;
-		sigrntwoprev=sigrntwoprevold;
-		e0ntwoprev=e0ntwoprevold;
-		sig0ntwoprev=sig0ntwoprevold;
+    outp=outpold;
+    outn=outnold;
+    Rptwoprev=Rptwoprevold;
+    Rntwoprev=Rntwoprevold;
 
-		erptwoprev=erptwoprevold;
-		sigrptwoprev=sigrptwoprevold;
-		e0ptwoprev=e0ptwoprevold;
-		sig0ptwoprev=sig0ptwoprevold;
+    if (def > defold) {
+      inc = 1;
+    } else if (def < defold) {
+      inc = -1;
+    } else {
+      inc = incold;
+    }
 
-		Rp=Rpold;
-		Rn=Rnold;
+    erp=erpold;
+    sigrp=sigrpold;
 
-		nloop=nloopold;
+    ern=ernold;
+    sigrn=sigrnold;
 
-		if (incold == 1) {
+    erpmaxmax=erpmaxmaxold;
+    ernmaxmax=ernmaxmaxold;
 
-			if (e < eold) {
+    e0p=e0pold;
+    sig0p=sig0pold;
 
-				Rntwoprev=Rnold;    
-				erntwoprev=ernold;
-				sigrntwoprev=sigrnold;
-				e0ntwoprev=e0nold;
-				sig0ntwoprev=sig0nold;
+    e0n=e0nold;
+    sig0n=sig0nold;
 
-				ern=eold;
-				sigrn=sigold;
-				nloop=nloopold+1;
+    erntwoprev=erntwoprevold;
+    sigrntwoprev=sigrntwoprevold;
+    e0ntwoprev=e0ntwoprevold;
+    sig0ntwoprev=sig0ntwoprevold;
 
-				double sigy = -sigyieldn;
+    erptwoprev=erptwoprevold;
+    sigrptwoprev=sigrptwoprevold;
+    e0ptwoprev=e0ptwoprevold;
+    sig0ptwoprev=sig0ptwoprevold;
 
-				if (ern > ernmaxmaxold) {
-					ernmaxmax=ern;
-				} else {
-					ernmaxmax=ernmaxmaxold;
-				}
+    Rp=Rpold;
+    Rn=Rnold;
 
-				double sigstar=-sigy*a3*(abs(ernmaxmax)/eyieldp-a4);
+    nloop=nloopold;
 
-				if (abs(ernmaxmax) < eyieldp) {
-					sigstar = 0.0;
-				}
+    if (incold == 1) {
 
-				if (sigstar < 0.0) {
-					sigstar = 0.0;
-				}
+      if (e < eold) {
 
-				sigy = sigy - sigstar;
+        Rntwoprev=Rnold;
+        erntwoprev=ernold;
+        sigrntwoprev=sigrnold;
+        e0ntwoprev=e0nold;
+        sig0ntwoprev=sig0nold;
 
-				e0n=(sigy*(1.0-bn)+E0*ern-sigrn)/(E0*(1.0-bn));
-				sig0n=sigrn+E0*(e0n-ern);
+        ern=eold;
+        sigrn=sigold;
+        nloop=nloopold+1;
 
-				double em;
+        double sigy = -sigyieldn;
 
-				if (nloop==1) {
-					em=e0n;
-				} else if (nloop==2) {
-					em=-eyieldn;
-				} else {
-					em=erp;
-				}
+        if (ern > ernmaxmaxold) {
+          ernmaxmax=ern;
+        } else {
+          ernmaxmax=ernmaxmaxold;
+        }
 
-				double ksi=abs((em-e0n)/eyieldn);
+        double sigstar=-sigy*a3*(abs(ernmaxmax)/eyieldp-a4);
 
-				Rn = R0 - a1*ksi/(a2+ksi);
+        if (abs(ernmaxmax) < eyieldp) {
+          sigstar = 0.0;
+        }
 
-				if (Rn > Rnold) {
-					Rn = Rnold;
-				}
+        if (sigstar < 0.0) {
+          sigstar = 0.0;
+        }
 
-				double estn=(e-ern)/(e0n-ern);
-				double sigstn=bn*estn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*estn;
+        sigy = sigy - sigstar;
 
-				double sig=sigrn+sigstn*(sig0n-sigrn);
-				double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1+pow(estn,Rn))));
+        e0n=(sigy*(1.0-bn)+E0*ern-sigrn)/(E0*(1.0-bn));
+        sig0n=sigrn+E0*(e0n-ern);
 
-				double estnlimit=(e-erntwoprev)/(e0ntwoprev-erntwoprev);
-				double sigstnlimit=bn*estnlimit+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*estnlimit;
+        double em;
 
-				double siglimit=sigrntwoprev+sigstnlimit*(sig0ntwoprev-sigrntwoprev);
-				double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*(bn+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*(1.0-pow(estnlimit,Rntwoprev)/(1+pow(estnlimit,Rntwoprev))));
+        if (nloop==1) {
+          em=e0n;
+        } else if (nloop==2) {
+          em=-eyieldn;
+        } else {
+          em=erp;
+        }
 
-				double Rcontrol=Rntwoprev;
-				double estcontrol=(ern-erntwoprev)/(e0ntwoprev-erntwoprev);
-				double sigstcontrol=bn*estcontrol+((1-bn)/pow((1.0+pow(estcontrol,Rcontrol)),(1.0/Rcontrol)))*estcontrol;
-				double sigcontrol=sigrntwoprev+sigstcontrol*(sig0ntwoprev-sigrntwoprev);
+        double ksi=abs((em-e0n)/eyieldn);
 
-				if (sigrn < sigcontrol) {
-					outn=1;
-				} else {
-					outn=0;
-				}
+        Rn = R0 - a1*ksi/(a2+ksi);
 
-				if (ern < erntwoprev && outn==0) {
+        if (Rn > Rnold) {
+          Rn = Rnold;
+        }
 
-					if (sig < siglimit) {
+        double estn=(e-ern)/(e0n-ern);
+        double sigstn=bn*estn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*estn;
 
-						sig=siglimit;
-						Et=Etlimit;
-						ern=erntwoprev;
-						sigrn=sigrntwoprev;
-						e0n=e0ntwoprev;
-						sig0n=sig0ntwoprev;
-						Rn=Rntwoprev;
+        double sig=sigrn+sigstn*(sig0n-sigrn);
+        double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1+pow(estn,Rn))));
 
-					}
+        double estnlimit=(e-erntwoprev)/(e0ntwoprev-erntwoprev);
+        double sigstnlimit=bn*estnlimit+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*estnlimit;
 
-				}
+        double siglimit=sigrntwoprev+sigstnlimit*(sig0ntwoprev-sigrntwoprev);
+        double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*(bn+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*(1.0-pow(estnlimit,Rntwoprev)/(1+pow(estnlimit,Rntwoprev))));
 
-				F = sig;
-				stif = Et;
+        double Rcontrol=Rntwoprev;
+        double estcontrol=(ern-erntwoprev)/(e0ntwoprev-erntwoprev);
+        double sigstcontrol=bn*estcontrol+((1-bn)/pow((1.0+pow(estcontrol,Rcontrol)),(1.0/Rcontrol)))*estcontrol;
+        double sigcontrol=sigrntwoprev+sigstcontrol*(sig0ntwoprev-sigrntwoprev);
 
-			} else {
+        if (sigrn < sigcontrol) {
+          outn=1;
+        } else {
+          outn=0;
+        }
 
-				Rp=Rpold;
+        if (ern < erntwoprev && outn==0) {
 
-				double estp=(e-erp)/(e0p-erp);
-				double sigstp=bp*estp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*estp;
+          if (sig < siglimit) {
 
-				double sig=sigrp+sigstp*(sig0p-sigrp);
-				double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1+pow(estp,Rp))));
+            sig=siglimit;
+            Et=Etlimit;
+            ern=erntwoprev;
+            sigrn=sigrntwoprev;
+            e0n=e0ntwoprev;
+            sig0n=sig0ntwoprev;
+            Rn=Rntwoprev;
 
-				double estplimit=(e-erptwoprev)/(e0ptwoprev-erptwoprev);
-				double sigstplimit=bp*estplimit+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*estplimit;
+          }
 
-				double siglimit=sigrptwoprev+sigstplimit*(sig0ptwoprev-sigrptwoprev);
-				double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*(bp+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*(1.0-pow(estplimit,Rptwoprev)/(1+pow(estplimit,Rptwoprev))));
+        }
 
-				if (erp>erptwoprev && outp==0) {
+        F = sig;
+        stif = Et;
 
-					if (sig>siglimit) {
+      } else {
 
-						sig=siglimit;
-						Et=Etlimit;
-						erp=erptwoprev;
-						sigrp=sigrptwoprev;
-						e0p=e0ptwoprev;
-						sig0p=sig0ptwoprev;
-						Rp=Rptwoprev;
+        Rp=Rpold;
 
-					}
+        double estp=(e-erp)/(e0p-erp);
+        double sigstp=bp*estp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*estp;
 
-				}
+        double sig=sigrp+sigstp*(sig0p-sigrp);
+        double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1+pow(estp,Rp))));
 
-				F = sig;
-				stif = Et;
+        double estplimit=(e-erptwoprev)/(e0ptwoprev-erptwoprev);
+        double sigstplimit=bp*estplimit+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*estplimit;
 
-			}
-		}
+        double siglimit=sigrptwoprev+sigstplimit*(sig0ptwoprev-sigrptwoprev);
+        double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*(bp+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*(1.0-pow(estplimit,Rptwoprev)/(1+pow(estplimit,Rptwoprev))));
 
-		if (incold == -1) {
+        if (erp>erptwoprev && outp==0) {
 
-			if (e > eold) {
+          if (sig>siglimit) {
 
-				Rptwoprev=Rpold;
-				erptwoprev=erpold;
-				sigrptwoprev=sigrpold;
-				e0ptwoprev=e0pold;
-				sig0ptwoprev=sig0pold;
+            sig=siglimit;
+            Et=Etlimit;
+            erp=erptwoprev;
+            sigrp=sigrptwoprev;
+            e0p=e0ptwoprev;
+            sig0p=sig0ptwoprev;
+            Rp=Rptwoprev;
 
-				erp=eold;
-				sigrp=sigold;
-				nloop=nloopold+1;
-				double sigy = sigyieldp;
+          }
 
-				if (erp < erpmaxmaxold) {
-					erpmaxmax=erp;
-				} else {
-					erpmaxmax=erpmaxmaxold;
-				}
+        }
 
-				double sigstar=sigy*a5*(abs(erpmaxmax)/eyieldn-a6);
+        F = sig;
+        stif = Et;
 
-				if (abs(erpmaxmax) < eyieldn) {
-					sigstar = 0.0;
-				}
+      }
+    }
 
-				if (sigstar < 0.0) {
-					sigstar = 0.0;
-				}
+    if (incold == -1) {
 
-				sigy = sigy + sigstar;
+      if (e > eold) {
 
-				e0p = (sigy*(1.0-bp)+E0*erp-sigrp)/(E0*(1.0-bp));
-				sig0p = sigrp+E0*(e0p-erp);
+        Rptwoprev=Rpold;
+        erptwoprev=erpold;
+        sigrptwoprev=sigrpold;
+        e0ptwoprev=e0pold;
+        sig0ptwoprev=sig0pold;
 
-				double em;
+        erp=eold;
+        sigrp=sigold;
+        nloop=nloopold+1;
+        double sigy = sigyieldp;
 
-				if (nloop==1) {
-					em=e0p;
-				} else if (nloop==2) {
-					em=eyieldp;
-				} else {
-					em=ern;
-				}
+        if (erp < erpmaxmaxold) {
+          erpmaxmax=erp;
+        } else {
+          erpmaxmax=erpmaxmaxold;
+        }
 
-				double ksi = abs((em-e0p)/eyieldp);
+        double sigstar=sigy*a5*(abs(erpmaxmax)/eyieldn-a6);
 
-				Rp = R0 - a1*ksi/(a2+ksi);
+        if (abs(erpmaxmax) < eyieldn) {
+          sigstar = 0.0;
+        }
 
-				if (Rp > Rpold) {
-					Rp = Rpold;
-				}
+        if (sigstar < 0.0) {
+          sigstar = 0.0;
+        }
 
-				double estp=(e-erp)/(e0p-erp);
-				double sigstp=bp*estp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*estp;
+        sigy = sigy + sigstar;
 
-				double sig=sigrp+sigstp*(sig0p-sigrp);
-				double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
+        e0p = (sigy*(1.0-bp)+E0*erp-sigrp)/(E0*(1.0-bp));
+        sig0p = sigrp+E0*(e0p-erp);
 
-				double estplimit=(e-erptwoprev)/(e0ptwoprev-erptwoprev);
-				double sigstplimit=bp*estplimit+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*estplimit;
+        double em;
 
-				double siglimit=sigrptwoprev+sigstplimit*(sig0ptwoprev-sigrptwoprev);
-				double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*(bp+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*(1.0-pow(estplimit,Rptwoprev)/(1+pow(estplimit,Rptwoprev))));
+        if (nloop==1) {
+          em=e0p;
+        } else if (nloop==2) {
+          em=eyieldp;
+        } else {
+          em=ern;
+        }
 
-				double Rcontrol=Rptwoprev;
-				double estcontrol=(erp-erptwoprev)/(e0ptwoprev-erptwoprev);
-				double sigstcontrol=bp*estcontrol+((1-bp)/pow((1.0+pow(estcontrol,Rcontrol)),(1.0/Rcontrol)))*estcontrol;
-				double sigcontrol=sigrptwoprev+sigstcontrol*(sig0ptwoprev-sigrptwoprev);
+        double ksi = abs((em-e0p)/eyieldp);
 
-				if (sigrp > sigcontrol) {
-					outp=1;
-				} else {
-					outp=0;
-				}
+        Rp = R0 - a1*ksi/(a2+ksi);
 
-				if (erp > erptwoprev && outp == 0) {
-					if (sig>siglimit){
-						sig=siglimit;
-						Et=Etlimit;
-						erp=erptwoprev;
-						sigrp=sigrptwoprev;
-						e0p=e0ptwoprev;
-						sig0p=sig0ptwoprev;
-						Rp=Rptwoprev;
-					}
-				}
+        if (Rp > Rpold) {
+          Rp = Rpold;
+        }
 
-				F = sig;
-				stif = Et;
+        double estp=(e-erp)/(e0p-erp);
+        double sigstp=bp*estp+((1.0-bp)/pow((1+pow(estp,Rp)),(1.0/Rp)))*estp;
 
-			}
+        double sig=sigrp+sigstp*(sig0p-sigrp);
+        double Et=((sig0p-sigrp)/(e0p-erp))*(bp+((1.0-bp)/pow((1.0+pow(estp,Rp)),(1.0/Rp)))*(1.0-pow(estp,Rp)/(1.0+pow(estp,Rp))));
 
-			else {
+        double estplimit=(e-erptwoprev)/(e0ptwoprev-erptwoprev);
+        double sigstplimit=bp*estplimit+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*estplimit;
 
-				Rn=Rnold;
+        double siglimit=sigrptwoprev+sigstplimit*(sig0ptwoprev-sigrptwoprev);
+        double Etlimit=((sig0ptwoprev-sigrptwoprev)/(e0ptwoprev-erptwoprev))*(bp+((1.0-bp)/pow((1+pow(estplimit,Rptwoprev)),(1.0/Rptwoprev)))*(1.0-pow(estplimit,Rptwoprev)/(1+pow(estplimit,Rptwoprev))));
 
-				double estn=(e-ern)/(e0n-ern);
-				double sigstn=bn*estn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*estn;
+        double Rcontrol=Rptwoprev;
+        double estcontrol=(erp-erptwoprev)/(e0ptwoprev-erptwoprev);
+        double sigstcontrol=bp*estcontrol+((1-bp)/pow((1.0+pow(estcontrol,Rcontrol)),(1.0/Rcontrol)))*estcontrol;
+        double sigcontrol=sigrptwoprev+sigstcontrol*(sig0ptwoprev-sigrptwoprev);
 
-				double sig=sigrn+sigstn*(sig0n-sigrn);
-				double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
+        if (sigrp > sigcontrol) {
+          outp=1;
+        } else {
+          outp=0;
+        }
 
-				double estnlimit=(e-erntwoprev)/(e0ntwoprev-erntwoprev);
-				double sigstnlimit=bn*estnlimit+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*estnlimit;
+        if (erp > erptwoprev && outp == 0) {
+          if (sig>siglimit){
+            sig=siglimit;
+            Et=Etlimit;
+            erp=erptwoprev;
+            sigrp=sigrptwoprev;
+            e0p=e0ptwoprev;
+            sig0p=sig0ptwoprev;
+            Rp=Rptwoprev;
+          }
+        }
 
-				double siglimit=sigrntwoprev+sigstnlimit*(sig0ntwoprev-sigrntwoprev);
-				double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*(bn+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*(1.0-pow(estnlimit,Rntwoprev)/(1+pow(estnlimit,Rntwoprev))));
+        F = sig;
+        stif = Et;
 
-				if (ern < erntwoprev && outn == 0) {
+      }
 
-					if (sig < siglimit) {
+      else {
 
-						sig=siglimit;
-						Et=Etlimit;
-						ern=erntwoprev;
-						sigrn=sigrntwoprev;
-						e0n=e0ntwoprev;
-						sig0n=sig0ntwoprev;
-						Rn=Rntwoprev;
+        Rn=Rnold;
 
-					}
+        double estn=(e-ern)/(e0n-ern);
+        double sigstn=bn*estn+((1.0-bn)/pow((1+pow(estn,Rn)),(1.0/Rn)))*estn;
 
-				}
+        double sig=sigrn+sigstn*(sig0n-sigrn);
+        double Et=((sig0n-sigrn)/(e0n-ern))*(bn+((1.0-bn)/pow((1.0+pow(estn,Rn)),(1.0/Rn)))*(1.0-pow(estn,Rn)/(1.0+pow(estn,Rn))));
 
-				F = sig;
-				stif = Et;
+        double estnlimit=(e-erntwoprev)/(e0ntwoprev-erntwoprev);
+        double sigstnlimit=bn*estnlimit+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*estnlimit;
 
-			}
+        double siglimit=sigrntwoprev+sigstnlimit*(sig0ntwoprev-sigrntwoprev);
+        double Etlimit=((sig0ntwoprev-sigrntwoprev)/(e0ntwoprev-erntwoprev))*(bn+((1.0-bn)/pow((1+pow(estnlimit,Rntwoprev)),(1.0/Rntwoprev)))*(1.0-pow(estnlimit,Rntwoprev)/(1+pow(estnlimit,Rntwoprev))));
 
-		}
+        if (ern < erntwoprev && outn == 0) {
 
-	}
+          if (sig < siglimit) {
+
+            sig=siglimit;
+            Et=Etlimit;
+            ern=erntwoprev;
+            sigrn=sigrntwoprev;
+            e0n=e0ntwoprev;
+            sig0n=sig0ntwoprev;
+            Rn=Rntwoprev;
+
+          }
+
+        }
+
+        F = sig;
+        stif = Et;
+
+      }
+
+    }
+
+  }
 
 }
 
 double SteelMPF::getStrain()
 {
-	return def;
+  return def;
 }
 
 double SteelMPF::getStress()
 {
-	return F;
+  return F;
 }
 
 double SteelMPF::getTangent()
 {
-	return stif;
+  return stif;
 }
 
 int SteelMPF::commitState()
 {
 
-	// History variables
-	incold = inc;
+  // History variables
+  incold = inc;
 
-	Rptwoprevold = Rptwoprev;
-	Rntwoprevold = Rntwoprev;
+  Rptwoprevold = Rptwoprev;
+  Rntwoprevold = Rntwoprev;
 
-	outpold = outp;
-	outnold = outn;
+  outpold = outp;
+  outnold = outn;
 
-	erpold = erp;
-	sigrpold = sigrp;
+  erpold = erp;
+  sigrpold = sigrp;
 
-	ernold = ern;
-	sigrnold = sigrn;
+  ernold = ern;
+  sigrnold = sigrn;
 
-	erpmaxmaxold = erpmaxmax;
-	ernmaxmaxold = ernmaxmax;
+  erpmaxmaxold = erpmaxmax;
+  ernmaxmaxold = ernmaxmax;
 
-	e0pold = e0p;
-	sig0pold = sig0p;
+  e0pold = e0p;
+  sig0pold = sig0p;
 
-	e0nold = e0n;
-	sig0nold = sig0n;
+  e0nold = e0n;
+  sig0nold = sig0n;
 
-	erntwoprevold = erntwoprev;
-	sigrntwoprevold = sigrntwoprev;
-	e0ntwoprevold = e0ntwoprev;
-	sig0ntwoprevold = sig0ntwoprev;
+  erntwoprevold = erntwoprev;
+  sigrntwoprevold = sigrntwoprev;
+  e0ntwoprevold = e0ntwoprev;
+  sig0ntwoprevold = sig0ntwoprev;
 
-	erptwoprevold = erptwoprev;
-	sigrptwoprevold = sigrptwoprev;
-	e0ptwoprevold = e0ptwoprev;
-	sig0ptwoprevold = sig0ptwoprev;
+  erptwoprevold = erptwoprev;
+  sigrptwoprevold = sigrptwoprev;
+  e0ptwoprevold = e0ptwoprev;
+  sig0ptwoprevold = sig0ptwoprev;
 
-	Rpold = Rp;
-	Rnold = Rn;
+  Rpold = Rp;
+  Rnold = Rn;
 
-	nloopold = nloop;
+  nloopold = nloop;
 
-	// State variables
-	defold = def;
-	Fold = F;
-	stifold = stif;
+  // State variables
+  defold = def;
+  Fold = F;
+  stifold = stif;
 
-	return 0;
+  return 0;
 }
 
 int SteelMPF::revertToLastCommit()
 {
-	// Reset trial history variables to last committed state
-	inc = incold;
+  // Reset trial history variables to last committed state
+  inc = incold;
 
-	Rptwoprev = Rptwoprevold;
-	Rntwoprev = Rntwoprevold;
+  Rptwoprev = Rptwoprevold;
+  Rntwoprev = Rntwoprevold;
 
-	outp = outpold;
-	outn = outnold;
+  outp = outpold;
+  outn = outnold;
 
-	erp = erpold;
-	sigrp = sigrpold;
+  erp = erpold;
+  sigrp = sigrpold;
 
-	ern = ernold;
-	sigrn = sigrnold;
+  ern = ernold;
+  sigrn = sigrnold;
 
-	erpmaxmax = erpmaxmaxold;
-	ernmaxmax = ernmaxmaxold;
+  erpmaxmax = erpmaxmaxold;
+  ernmaxmax = ernmaxmaxold;
 
-	e0p = e0pold;
-	sig0p = sig0pold;
+  e0p = e0pold;
+  sig0p = sig0pold;
 
-	e0n = e0nold;
-	sig0n = sig0nold;
+  e0n = e0nold;
+  sig0n = sig0nold;
 
-	erntwoprev = erntwoprevold;
-	sigrntwoprev = sigrntwoprevold;
-	e0ntwoprev = e0ntwoprevold;
-	sig0ntwoprev = sig0ntwoprevold;
+  erntwoprev = erntwoprevold;
+  sigrntwoprev = sigrntwoprevold;
+  e0ntwoprev = e0ntwoprevold;
+  sig0ntwoprev = sig0ntwoprevold;
 
-	erptwoprev = erptwoprevold;
-	sigrptwoprev = sigrptwoprevold;
-	e0ptwoprev = e0ptwoprevold;
-	sig0ptwoprev = sig0ptwoprevold;
+  erptwoprev = erptwoprevold;
+  sigrptwoprev = sigrptwoprevold;
+  e0ptwoprev = e0ptwoprevold;
+  sig0ptwoprev = sig0ptwoprevold;
 
-	Rp = Rpold;
-	Rn = Rnold;
+  Rp = Rpold;
+  Rn = Rnold;
 
-	nloop = nloopold;
+  nloop = nloopold;
 
-	// Reset trial state variables to last committed state
-	def = defold;
-	F = Fold;
-	stif = stifold;
+  // Reset trial state variables to last committed state
+  def = defold;
+  F = Fold;
+  stif = stifold;
 
-	return 0;
+  return 0;
 }
 
 int SteelMPF::revertToStart()
 {
-	// TRIAL History variables
-	inc = 0;
+  // TRIAL History variables
+  inc = 0;
 
-	Rptwoprev = 0.0;
-	Rntwoprev = 0.0;
+  Rptwoprev = 0.0;
+  Rntwoprev = 0.0;
 
-	outp = 0;
-	outn = 0;
+  outp = 0;
+  outn = 0;
 
-	erp = 0.0;
-	sigrp = 0.0;
+  erp = 0.0;
+  sigrp = 0.0;
 
-	ern = 0.0;
-	sigrn = 0.0;
+  ern = 0.0;
+  sigrn = 0.0;
 
-	erpmaxmax = 0.0;
-	ernmaxmax = 0.0;
+  erpmaxmax = 0.0;
+  ernmaxmax = 0.0;
 
-	e0p = 0.0;
-	sig0p = 0.0;
+  e0p = 0.0;
+  sig0p = 0.0;
 
-	e0n = 0.0;
-	sig0n = 0.0;
+  e0n = 0.0;
+  sig0n = 0.0;
 
-	erntwoprev = 0.0;
-	sigrntwoprev = 0.0;
-	e0ntwoprev = 0.0;
-	sig0ntwoprev = 0.0;
+  erntwoprev = 0.0;
+  sigrntwoprev = 0.0;
+  e0ntwoprev = 0.0;
+  sig0ntwoprev = 0.0;
 
-	erptwoprev = 0.0;
-	sigrptwoprev = 0.0;
-	e0ptwoprev = 0.0;
-	sig0ptwoprev = 0.0;
+  erptwoprev = 0.0;
+  sigrptwoprev = 0.0;
+  e0ptwoprev = 0.0;
+  sig0ptwoprev = 0.0;
 
-	Rp = R0;
-	Rn = R0;
+  Rp = R0;
+  Rn = R0;
 
-	nloop = 0;
+  nloop = 0;
 
-	// CONVERGED History variables
-	incold = 0;
+  // CONVERGED History variables
+  incold = 0;
 
-	Rptwoprevold = 0.0;
-	Rntwoprevold = 0.0;
+  Rptwoprevold = 0.0;
+  Rntwoprevold = 0.0;
 
-	outpold = 0;
-	outnold = 0;
+  outpold = 0;
+  outnold = 0;
 
-	erpold = 0.0;
-	sigrpold = 0.0;
+  erpold = 0.0;
+  sigrpold = 0.0;
 
-	ernold = 0.0;
-	sigrnold = 0.0;
+  ernold = 0.0;
+  sigrnold = 0.0;
 
-	erpmaxmaxold = 0.0;
-	ernmaxmaxold = 0.0;
+  erpmaxmaxold = 0.0;
+  ernmaxmaxold = 0.0;
 
-	e0pold = 0.0;
-	sig0pold = 0.0;
+  e0pold = 0.0;
+  sig0pold = 0.0;
 
-	e0nold = 0.0;
-	sig0nold = 0.0;
+  e0nold = 0.0;
+  sig0nold = 0.0;
 
-	erntwoprevold = 0.0;
-	sigrntwoprevold = 0.0;
-	e0ntwoprevold = 0.0;
-	sig0ntwoprevold = 0.0;
+  erntwoprevold = 0.0;
+  sigrntwoprevold = 0.0;
+  e0ntwoprevold = 0.0;
+  sig0ntwoprevold = 0.0;
 
-	erptwoprevold = 0.0;
-	sigrptwoprevold = 0.0;
-	e0ptwoprevold = 0.0;
-	sig0ptwoprevold = 0.0;
+  erptwoprevold = 0.0;
+  sigrptwoprevold = 0.0;
+  e0ptwoprevold = 0.0;
+  sig0ptwoprevold = 0.0;
 
-	Rpold = R0;
-	Rnold = R0;
+  Rpold = R0;
+  Rnold = R0;
 
-	nloopold = 0;
+  nloopold = 0;
 
-	// TRIAL State variables
-	def = 0.0;
-	F = 0.0;
-	stif = E0;
+  // TRIAL State variables
+  def = 0.0;
+  F = 0.0;
+  stif = E0;
 
-	// CONVERGED State variables
-	defold = 0.0;
-	Fold = 0.0;
-	stifold = E0; 
+  // CONVERGED State variables
+  defold = 0.0;
+  Fold = 0.0;
+  stifold = E0;
 
-	eyieldp = sigyieldp/E0; 
-	eyieldn = sigyieldn/E0;
+  eyieldp = sigyieldp/E0;
+  eyieldn = sigyieldn/E0;
 
-	return 0;
+  return 0;
 }
 
 UniaxialMaterial* SteelMPF::getCopy()
 {
-	SteelMPF* theCopy = new SteelMPF(this->getTag(), sigyieldp, sigyieldn, E0, bp, bn, R0, aa1, a2, a3, a4, a5, a6); 
+  SteelMPF* theCopy = new SteelMPF(this->getTag(), sigyieldp, sigyieldn, E0, bp, bn, R0, aa1, a2, a3, a4, a5, a6);
 
-	// CONVERGED History variables
-	theCopy-> incold = incold;
+  // CONVERGED History variables
+  theCopy-> incold = incold;
 
-	theCopy-> Rptwoprevold = Rptwoprevold;
-	theCopy-> Rntwoprevold = Rntwoprevold;
+  theCopy-> Rptwoprevold = Rptwoprevold;
+  theCopy-> Rntwoprevold = Rntwoprevold;
 
-	theCopy-> outpold = outpold;
-	theCopy-> outnold = outnold;
+  theCopy-> outpold = outpold;
+  theCopy-> outnold = outnold;
 
-	theCopy-> erpold = erpold;
-	theCopy-> sigrpold = sigrpold;
+  theCopy-> erpold = erpold;
+  theCopy-> sigrpold = sigrpold;
 
-	theCopy-> ernold = ernold;
-	theCopy-> sigrnold = sigrnold;
+  theCopy-> ernold = ernold;
+  theCopy-> sigrnold = sigrnold;
 
-	theCopy-> erpmaxmaxold = erpmaxmaxold;
-	theCopy-> ernmaxmaxold = ernmaxmaxold;
+  theCopy-> erpmaxmaxold = erpmaxmaxold;
+  theCopy-> ernmaxmaxold = ernmaxmaxold;
 
-	theCopy-> e0pold = e0pold;
-	theCopy-> sig0pold = sig0pold;
+  theCopy-> e0pold = e0pold;
+  theCopy-> sig0pold = sig0pold;
 
-	theCopy-> e0nold = e0nold;
-	theCopy-> sig0nold = sig0nold;
+  theCopy-> e0nold = e0nold;
+  theCopy-> sig0nold = sig0nold;
 
-	theCopy-> erntwoprevold = erntwoprevold;
-	theCopy-> sigrntwoprevold = sigrntwoprevold;
-	theCopy-> e0ntwoprevold = e0ntwoprevold;
-	theCopy-> sig0ntwoprevold = sig0ntwoprevold;
+  theCopy-> erntwoprevold = erntwoprevold;
+  theCopy-> sigrntwoprevold = sigrntwoprevold;
+  theCopy-> e0ntwoprevold = e0ntwoprevold;
+  theCopy-> sig0ntwoprevold = sig0ntwoprevold;
 
-	theCopy-> erptwoprevold = erptwoprevold;
-	theCopy-> sigrptwoprevold = sigrptwoprevold;
-	theCopy-> e0ptwoprevold = e0ptwoprevold;
-	theCopy-> sig0ptwoprevold = sig0ptwoprevold;
+  theCopy-> erptwoprevold = erptwoprevold;
+  theCopy-> sigrptwoprevold = sigrptwoprevold;
+  theCopy-> e0ptwoprevold = e0ptwoprevold;
+  theCopy-> sig0ptwoprevold = sig0ptwoprevold;
 
-	theCopy-> Rpold = Rpold;
-	theCopy-> Rnold = Rnold;
+  theCopy-> Rpold = Rpold;
+  theCopy-> Rnold = Rnold;
 
-	theCopy-> nloopold = nloopold;
+  theCopy-> nloopold = nloopold;
 
-	// TRIAL History variables
-	theCopy-> inc = inc;
+  // TRIAL History variables
+  theCopy-> inc = inc;
 
-	theCopy-> Rptwoprev = Rptwoprev;
-	theCopy-> Rntwoprev = Rntwoprev;
+  theCopy-> Rptwoprev = Rptwoprev;
+  theCopy-> Rntwoprev = Rntwoprev;
 
-	theCopy-> outp = outp;
-	theCopy-> outn = outn;
+  theCopy-> outp = outp;
+  theCopy-> outn = outn;
 
-	theCopy-> erp = erp;
-	theCopy-> sigrp = sigrp;
+  theCopy-> erp = erp;
+  theCopy-> sigrp = sigrp;
 
-	theCopy-> ern = ern;
-	theCopy-> sigrn = sigrn;
+  theCopy-> ern = ern;
+  theCopy-> sigrn = sigrn;
 
-	theCopy-> erpmaxmax = erpmaxmax;
-	theCopy-> ernmaxmax = ernmaxmax;
+  theCopy-> erpmaxmax = erpmaxmax;
+  theCopy-> ernmaxmax = ernmaxmax;
 
-	theCopy-> e0p = e0p;
-	theCopy-> sig0p = sig0p;
+  theCopy-> e0p = e0p;
+  theCopy-> sig0p = sig0p;
 
-	theCopy-> e0n = e0n;
-	theCopy-> sig0n = sig0n;
+  theCopy-> e0n = e0n;
+  theCopy-> sig0n = sig0n;
 
-	theCopy-> erntwoprev = erntwoprev;
-	theCopy-> sigrntwoprev = sigrntwoprev;
-	theCopy-> e0ntwoprev = e0ntwoprev;
-	theCopy-> sig0ntwoprev = sig0ntwoprev;
+  theCopy-> erntwoprev = erntwoprev;
+  theCopy-> sigrntwoprev = sigrntwoprev;
+  theCopy-> e0ntwoprev = e0ntwoprev;
+  theCopy-> sig0ntwoprev = sig0ntwoprev;
 
-	theCopy-> erptwoprev = erptwoprev;
-	theCopy-> sigrptwoprev = sigrptwoprev;
-	theCopy-> e0ptwoprev = e0ptwoprev;
-	theCopy-> sig0ptwoprev = sig0ptwoprev;
+  theCopy-> erptwoprev = erptwoprev;
+  theCopy-> sigrptwoprev = sigrptwoprev;
+  theCopy-> e0ptwoprev = e0ptwoprev;
+  theCopy-> sig0ptwoprev = sig0ptwoprev;
 
-	theCopy-> Rp = Rp;
-	theCopy-> Rn = Rn;
+  theCopy-> Rp = Rp;
+  theCopy-> Rn = Rn;
 
-	theCopy-> nloop = nloop;
+  theCopy-> nloop = nloop;
 
-	// CONVERGED State variables
-	theCopy->defold = defold;
-	theCopy->Fold = Fold;
-	theCopy->stifold = stifold;
+  // CONVERGED State variables
+  theCopy->defold = defold;
+  theCopy->Fold = Fold;
+  theCopy->stifold = stifold;
 
-	// TRIAL State variables
-	theCopy->def = def;
-	theCopy->F = F;
-	theCopy->stif = stif;
+  // TRIAL State variables
+  theCopy->def = def;
+  theCopy->F = F;
+  theCopy->stif = stif;
 
-	return theCopy;
+  return theCopy;
 }
 
 int SteelMPF::sendSelf (int commitTag, Channel& theChannel)
 {
-	int res = 0;
-	static Vector data(42);
+  int res = 0;
+  static Vector data(42);
 
-	data(0) = this->getTag();
+  data(0) = this->getTag();
 
-	// Material properties
-	data(1) = sigyieldp;
-	data(2) = sigyieldn;
-	data(3) = E0;
-	data(4) = bp;
-	data(5) = bn;
-	data(6) = R0;
-	data(7) = aa1;
-	data(8) = a2;
-	data(9) = a3;
-	data(10) = a4;
-	data(11) = a5;
-	data(12) = a6;
+  // Material properties
+  data(1) = sigyieldp;
+  data(2) = sigyieldn;
+  data(3) = E0;
+  data(4) = bp;
+  data(5) = bn;
+  data(6) = R0;
+  data(7) = aa1;
+  data(8) = a2;
+  data(9) = a3;
+  data(10) = a4;
+  data(11) = a5;
+  data(12) = a6;
 
-	// CONVERGED History variables
-	data(13) = incold;
+  // CONVERGED History variables
+  data(13) = incold;
 
-	data(14) = Rptwoprevold;
-	data(15) = Rntwoprevold;
+  data(14) = Rptwoprevold;
+  data(15) = Rntwoprevold;
 
-	data(16) = outpold;
-	data(17) = outnold;
+  data(16) = outpold;
+  data(17) = outnold;
 
-	data(18) = erpold;
-	data(19) = sigrpold;
+  data(18) = erpold;
+  data(19) = sigrpold;
 
-	data(20) = ernold;
-	data(21) = sigrnold;
+  data(20) = ernold;
+  data(21) = sigrnold;
 
-	data(22) = erpmaxmaxold;
-	data(23) = ernmaxmaxold;
+  data(22) = erpmaxmaxold;
+  data(23) = ernmaxmaxold;
 
-	data(24) = e0pold;
-	data(25) = sig0pold;
+  data(24) = e0pold;
+  data(25) = sig0pold;
 
-	data(26) = e0nold;
-	data(27) = sig0nold;
+  data(26) = e0nold;
+  data(27) = sig0nold;
 
-	data(28) = erntwoprevold;
-	data(29) = sigrntwoprevold;
-	data(30) = e0ntwoprevold;
-	data(31) = sig0ntwoprevold;
+  data(28) = erntwoprevold;
+  data(29) = sigrntwoprevold;
+  data(30) = e0ntwoprevold;
+  data(31) = sig0ntwoprevold;
 
-	data(32) = erptwoprevold;
-	data(33) = sigrptwoprevold;
-	data(34) = e0ptwoprevold;
-	data(35) = sig0ptwoprevold;
+  data(32) = erptwoprevold;
+  data(33) = sigrptwoprevold;
+  data(34) = e0ptwoprevold;
+  data(35) = sig0ptwoprevold;
 
-	data(36) = Rpold;
-	data(37) = Rnold;
+  data(36) = Rpold;
+  data(37) = Rnold;
 
-	data(38) = nloopold;
+  data(38) = nloopold;
 
-	// CONVERGED State variables
-	data(39) = defold;
-	data(40) = Fold;
-	data(41) = stifold;
+  // CONVERGED State variables
+  data(39) = defold;
+  data(40) = Fold;
+  data(41) = stifold;
 
-	// Data is only sent after convergence, so no trial variables
-	// need to be sent through data vector
+  // Data is only sent after convergence, so no trial variables
+  // need to be sent through data vector
 
-	res = theChannel.sendVector(this->getDbTag(), commitTag, data);
-	if (res < 0) 
-		opserr << "SteelMPF::sendSelf() - failed to send data\n";
+  res = theChannel.sendVector(this->getDbTag(), commitTag, data);
+  if (res < 0)
+    opserr << "SteelMPF::sendSelf() - failed to send data\n";
 
-	return res;
+  return res;
 }
 
 int SteelMPF::recvSelf (int commitTag, Channel& theChannel, FEM_ObjectBroker& theBroker)
 {
-	int res = 0;
+  int res = 0;
 
-	static Vector data(42);
-	res = theChannel.recvVector(this->getDbTag(), commitTag, data);
+  static Vector data(42);
+  res = theChannel.recvVector(this->getDbTag(), commitTag, data);
 
-	if (res < 0) {
-		opserr << "SteelMPF::recvSelf() - failed to receive data\n";
-		this->setTag(0);      
-	}
-	else {
-		this->setTag(int(data(0)));
+  if (res < 0) {
+    opserr << "SteelMPF::recvSelf() - failed to receive data\n";
+    this->setTag(0);
+  }
+  else {
+    this->setTag(int(data(0)));
 
-		// Material properties
-		sigyieldp = data(1);
-		sigyieldn = data(2);
-		E0 = data(3);
-		bp = data(4);
-		bn = data(5);
-		R0 = data(6);
-		aa1 = data(7);
-		a2 = data(8);
-		a3 = data(9);
-		a4 = data(10);
-		a5 = data(11);
-		a6 = data(12);
+    // Material properties
+    sigyieldp = data(1);
+    sigyieldn = data(2);
+    E0 = data(3);
+    bp = data(4);
+    bn = data(5);
+    R0 = data(6);
+    aa1 = data(7);
+    a2 = data(8);
+    a3 = data(9);
+    a4 = data(10);
+    a5 = data(11);
+    a6 = data(12);
 
-		// CONVERGED History variables
-		incold = int(data(13));
+    // CONVERGED History variables
+    incold = int(data(13));
 
-		Rptwoprevold = data(14);
-		Rntwoprevold = data(15);
+    Rptwoprevold = data(14);
+    Rntwoprevold = data(15);
 
-		outpold = int(data(16));
-		outnold = int(data(17));
+    outpold = int(data(16));
+    outnold = int(data(17));
 
-		erpold = data(18);
-		sigrpold = data(19);
+    erpold = data(18);
+    sigrpold = data(19);
 
-		ernold = data(20);
-		sigrnold = data(21);
+    ernold = data(20);
+    sigrnold = data(21);
 
-		erpmaxmaxold = data(22);
-		ernmaxmaxold = data(23);
+    erpmaxmaxold = data(22);
+    ernmaxmaxold = data(23);
 
-		e0pold = data(24);
-		sig0pold = data(25);
+    e0pold = data(24);
+    sig0pold = data(25);
 
-		e0nold = data(26);
-		sig0nold = data(27);
+    e0nold = data(26);
+    sig0nold = data(27);
 
-		erntwoprevold = data(28);
-		sigrntwoprevold = data(29);
-		e0ntwoprevold = data(30);
-		sig0ntwoprevold = data(31);
+    erntwoprevold = data(28);
+    sigrntwoprevold = data(29);
+    e0ntwoprevold = data(30);
+    sig0ntwoprevold = data(31);
 
-		erptwoprevold = data(32);
-		sigrptwoprevold = data(33);
-		e0ptwoprevold = data(34);
-		sig0ptwoprevold = data(35);
+    erptwoprevold = data(32);
+    sigrptwoprevold = data(33);
+    e0ptwoprevold = data(34);
+    sig0ptwoprevold = data(35);
 
-		Rpold = data(36);
-		Rnold = data(37);
+    Rpold = data(36);
+    Rnold = data(37);
 
-		nloopold = int(data(38));
+    nloopold = int(data(38));
 
-		// CONVERGED State variables
-		defold = data(39);
-		Fold = data(40);
-		stifold = data(41);
+    // CONVERGED State variables
+    defold = data(39);
+    Fold = data(40);
+    stifold = data(41);
 
-		// Copy converged history values into trial values since data is only
-		// sent (received) after convergence
-		inc = incold;
+    // Copy converged history values into trial values since data is only
+    // sent (received) after convergence
+    inc = incold;
 
-		Rptwoprev = Rptwoprevold;
-		Rntwoprev = Rntwoprevold;
+    Rptwoprev = Rptwoprevold;
+    Rntwoprev = Rntwoprevold;
 
-		outp = outpold;
-		outn = outnold;
+    outp = outpold;
+    outn = outnold;
 
-		erp = erpold;
-		sigrp = sigrpold;
+    erp = erpold;
+    sigrp = sigrpold;
 
-		ern = ernold;
-		sigrn = sigrnold;
+    ern = ernold;
+    sigrn = sigrnold;
 
-		erpmaxmax = erpmaxmaxold;
-		ernmaxmax = ernmaxmaxold;
+    erpmaxmax = erpmaxmaxold;
+    ernmaxmax = ernmaxmaxold;
 
-		e0p = e0pold;
-		sig0p = sig0pold;
+    e0p = e0pold;
+    sig0p = sig0pold;
 
-		e0n = e0nold;
-		sig0n = sig0nold;
+    e0n = e0nold;
+    sig0n = sig0nold;
 
-		erntwoprev = erntwoprevold;
-		sigrntwoprev = sigrntwoprevold;
-		e0ntwoprev = e0ntwoprevold;
-		sig0ntwoprev = sig0ntwoprevold;
+    erntwoprev = erntwoprevold;
+    sigrntwoprev = sigrntwoprevold;
+    e0ntwoprev = e0ntwoprevold;
+    sig0ntwoprev = sig0ntwoprevold;
 
-		erptwoprev = erptwoprevold;
-		sigrptwoprev = sigrptwoprevold;
-		e0ptwoprev = e0ptwoprevold;
-		sig0ptwoprev = sig0ptwoprevold;
+    erptwoprev = erptwoprevold;
+    sigrptwoprev = sigrptwoprevold;
+    e0ptwoprev = e0ptwoprevold;
+    sig0ptwoprev = sig0ptwoprevold;
 
-		Rp = Rpold;
-		Rn = Rnold;
+    Rp = Rpold;
+    Rn = Rnold;
 
-		nloop = nloopold;
+    nloop = nloopold;
 
-		// Copy converged state values into trial values
-		def = defold;
-		F = Fold;
-		stif = stifold;
+    // Copy converged state values into trial values
+    def = defold;
+    F = Fold;
+    stif = stifold;
 
-	}
+  }
 
-	return res; 
+  return res;
 }
 
 void SteelMPF::Print (OPS_Stream& s, int flag)
@@ -1330,7 +1340,7 @@ void SteelMPF::Print (OPS_Stream& s, int flag)
         s << " a3 = " << a5 << "\n";
         s << " a4 = " << a6 << "\n\n";
     }
-    
+
     if (flag == OPS_PRINT_PRINTMODEL_JSON) {
         s << "\t\t\t{";
         s << "\"name\": \"" << this->getTag() << "\", ";


### PR DESCRIPTION
## Fix `R` degradation in `SteelMPF` when strain history starts at zero

This PR fixes a bug in `SteelMPF` that caused incorrect degradation of the curvature parameter `R` when the strain history starts at $\varepsilon = 0$.

The issue led to inconsistent responses for equivalent loading histories depending on whether `-prependZero` was used in the `Path` time series.

Adapted from OpenSees [#1734](https://github.com/OpenSees/OpenSees/pull/1734) / [97bccae](https://github.com/OpenSees/OpenSees/commit/97bccae777cd2266743d367ec18cb64b1e2d5bc0).

### Reproduction

<table>
<tr>
<td align="center"><b>Current behavior</b></td>
<td align="center"><b>Behavior with this PR</b></td>
</tr>
<tr>
<td>
<img width="100%" alt="current behavior" src="https://github.com/user-attachments/assets/0fb7e220-045a-4b96-b55e-a24921c061fb" />
</td>
<td>
<img width="100%" alt="fixed behavior" src="https://github.com/user-attachments/assets/634e66fc-1851-408d-afae-aa91497dfb22" />
</td>
</tr>
</table>

### Test script

```python
import matplotlib.pyplot as plt
import numpy as np
import xara

E = 29000.0
FY = 50.0
B_P = 0.02
B_N = 0.02
R0 = 20.0
C_R1 = 0.925
C_R2 = 0.15
EPS_Y = FY / E

EPS_PEAK = 2.0 * EPS_Y
N = 10
D = np.linspace(0.0, EPS_PEAK, N, endpoint=False)
DISP_HISTORY = np.r_[D, EPS_PEAK - D, -D, -(EPS_PEAK - D)]


def _scalar(response):
    return float(response[0] if hasattr(response, "__getitem__") else response)


def run_simulation(disp_history, prepend_zero=False):
    model = xara.Model(ndm=1, ndf=1)
    model.node(1, (0.0,))
    model.fix(1, (1,))
    model.node(2, (0.0,))
    model.uniaxialMaterial(
        "SteelMPF", 1,
        FY, FY, E, B_P, B_N, R0, C_R1, C_R2,
    )
    model.element("zeroLength", 1, (1, 2), mat=1, dir=1)

    dt = 1.0
    extras = {"useLast": True}
    if prepend_zero:
        extras["prependZero"] = True
    model.timeSeries("Path", 1, dt=dt, values=list(disp_history), **extras)
    model.pattern("Plain", 1, 1)
    model.sp(2, 1, 1.0, pattern=1)
    model.integrator("LoadControl", dt)
    model.constraints("Transformation")
    model.numberer("Plain")
    model.system("UmfPack")
    model.analysis("Static", "-noWarnings")

    n = len(disp_history)
    stress = np.zeros(n)
    strain = np.zeros(n)
    time = np.zeros(n)
    for i in range(n):
        if model.analyze(1) != 0:
            raise RuntimeError("analyze failed at step %d/%d" % (i + 1, n))
        stress[i] = _scalar(model.eleResponse(1, "material", 1, "stress"))
        strain[i] = _scalar(model.eleResponse(1, "material", 1, "strain"))
        time[i] = model.getTime()
    return stress, strain, time


def main():
    runs = (
        (run_simulation(DISP_HISTORY, False), "prepend_zero=False", "-x"),
        (run_simulation(DISP_HISTORY, True), "prepend_zero=True", "--o"),
    )

    fig, (ax_t, ax_ss) = plt.subplots(2, 1, figsize=(5.5, 6.0))
    for (s, e, t), lab, sty in runs:
        en = e / EPS_Y
        ax_t.plot(t, en, sty, label=lab, lw=1.2, markersize=4)
        ax_ss.plot(en, s / FY, sty, label=lab, lw=1.2, markersize=4)

    ax_t.set_ylabel(r"$\varepsilon / \varepsilon_y$")
    ax_t.set_xlabel("pseudo-time")
    ax_t.axhline(0.0, color="0.8", lw=0.8)
    ax_t.grid(True, alpha=0.35)

    ax_ss.set_xlabel(r"$\varepsilon / \varepsilon_y$")
    ax_ss.set_ylabel(r"$\sigma / f_y$")
    ax_ss.axhline(0.0, color="0.8", lw=0.8)
    ax_ss.axvline(0.0, color="0.8", lw=0.8)
    ax_ss.grid(True, alpha=0.35)
    ax_ss.legend(loc="best", fontsize=8)

    fig.tight_layout()
    fig.savefig("demo_prepend_zero_bug.png", dpi=150)
    plt.close(fig)
    print("Wrote demo_prepend_zero_bug.png")


if __name__ == "__main__":
    main()
```
