### PR TITLE
Return consistent tangent in Penalty and Lagrange constraints

### DIFF
--- a/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.cpp
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.cpp
@@ -21,7 +21,7 @@
 // Purpose: This file contains the code for implementing the methods
 // of the LagrangeMP_FE class interface.
 //
-// Written: fmk 
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
@@ -54,54 +54,63 @@ LagrangeMP_FE::LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &TheMP,
   myID( TheMP.getConstrainedDOFs().Size()
         + TheMP.getRetainedDOFs().Size()
         + TheMP.getRetainedDOFs().Size()), // *see note 1
-  alpha(Alpha), theMP(&TheMP),
-  theConstrainedNode(0), theRetainedNode(0),
-  theDofGroup(&theGroup), tang(0), resid(0)
+  theMP(&TheMP),
+  theConstrainedNode(nullptr), theRetainedNode(nullptr),
+  theDofGroup(&theGroup), tang(nullptr), sysTang(nullptr), resid(nullptr),
+  timeVarying(TheMP.isTimeVarying()), urLoaded(false),
+  alpha(Alpha),
+  numU(TheMP.getConstrainedDOFs().Size() + TheMP.getRetainedDOFs().Size())
 {
   const Matrix &constraint = theMP->getConstraint();
   int noRows = constraint.noRows();
   int noCols = constraint.noCols();
   int size = 2*noRows+noCols;
-  
+
   tang = new Matrix(size,size);
+  sysTang = new Matrix(size,size);
   resid = new Vector(size);
-  tang->Zero();        
+  if (tang == nullptr || sysTang == nullptr || resid == nullptr ||
+      tang->noCols() == 0 || sysTang->noCols() == 0 || resid->Size() == 0) {
+    opserr << "FATAL LagrangeMP_FE::LagrangeMP_FE() - out of memory\n";
+    exit(-1);
+  }
+  tang->Zero();
+  sysTang->Zero();
   resid->Zero();
 
-  theRetainedNode = theDomain.getNode(theMP->getNodeRetained());    
+  theRetainedNode = theDomain.getNode(theMP->getNodeRetained());
   theConstrainedNode = theDomain.getNode(theMP->getNodeConstrained());
 
-  if (theRetainedNode == 0) {
+  if (theRetainedNode == nullptr) {
     opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
     opserr << "- no asscoiated Retained Node\n";
     exit(-1);
   }
-  
-  if (theConstrainedNode == 0) {
+
+  if (theConstrainedNode == nullptr) {
     opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
     opserr << "- no asscoiated Constrained Node\n";
     exit(-1);
   }
-  
-  if (theMP->isTimeVarying() == false) {
+
+  if (!timeVarying)
     this->determineTangent();
-  }
-  
+
   // set the myDOF_Groups tags indicating the attached id's of the
   // DOF_Group objects
   DOF_Group *theConstrainedNodesDOFs = theConstrainedNode->getDOF_GroupPtr();
   if (theConstrainedNodesDOFs == 0) {
     opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
     opserr << " - no DOF_Group with Constrained Node\n";
-    exit(-1);        
-  }    
+    exit(-1);
+  }
 
   DOF_Group *theRetainedNodesDOFs = theRetainedNode->getDOF_GroupPtr();
   if (theRetainedNodesDOFs == 0) {
     opserr << "WARNING LagrangeMP_FE::LagrangeMP_FE()";
     opserr << " - no DOF_Group with Retained Node\n";
-    exit(-1);        
-  }            
+    exit(-1);
+  }
 
 
   myDOF_Groups(0) = theConstrainedNodesDOFs->getTag();
@@ -111,11 +120,13 @@ LagrangeMP_FE::LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &TheMP,
 
 LagrangeMP_FE::~LagrangeMP_FE()
 {
-  if (tang != 0)
+  if (tang != nullptr)
     delete tang;
-  if (resid != 0)
+  if (sysTang != nullptr)
+    delete sysTang;
+  if (resid != nullptr)
     delete resid;
-}    
+}
 
 // void setID(int index, int value);
 //        Method to set the correMPonding index of the ID to value.
@@ -137,22 +148,22 @@ LagrangeMP_FE::setID(AnalysisModel& theModel)
     opserr << "WARNING LagrangeMP_FE::setID(void)";
     opserr << " - no DOF_Group with Constrained Node\n";
     return -2;
-  }    
+  }
 
   const ID &constrainedDOFs = theMP->getConstrainedDOFs();
-  const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();    
-  
+  const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();
+
   int size1 = constrainedDOFs.Size();
   for (int i=0; i<size1; i++) {
     int constrained = constrainedDOFs(i);
-    if (constrained < 0 || 
+    if (constrained < 0 ||
       constrained >= theConstrainedNode->getNumberDOF()) {
-      
+
       opserr << "WARNING LagrangeMP_FE::setID(void) - unknown DOF ";
       opserr << constrained << " at Node\n";
       myID(i) = -1; // modify so nothing will be added to equations
       result = -3;
-    }            
+    }
     else {
       if (constrained >= theConstrainedNodesID.Size()) {
         opserr << "WARNING LagrangeMP_FE::setID(void) - ";
@@ -176,10 +187,10 @@ LagrangeMP_FE::setID(AnalysisModel& theModel)
       opserr << "WARNING LagrangeMP_FE::setID()";
       opserr << " - no DOF_Group with Retained Node\n";
       return -2;
-  }    
-  
+  }
+
   const ID &RetainedDOFs = theMP->getRetainedDOFs();
-  const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();    
+  const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();
 
   int size2 = RetainedDOFs.Size();
   for (int j=0; j<size2; j++) {
@@ -189,12 +200,12 @@ LagrangeMP_FE::setID(AnalysisModel& theModel)
           opserr << retained << " at Node\n";
           myID(j+size1) = -1; // modify so nothing will be added
           result = -3;
-      }            
+      }
       else {
           if (retained >= theRetainedNodesID.Size()) {
               opserr << "WARNING LagrangeMP_FE::setID(void) - ";
               opserr << " Nodes DOF_Group too small\n";
-              myID(j+size1) = -1; // modify so nothing will be added 
+              myID(j+size1) = -1; // modify so nothing will be added
               result = -4;
           }
           else
@@ -205,25 +216,95 @@ LagrangeMP_FE::setID(AnalysisModel& theModel)
   // finally set the ID corresponding to the ID's at the LagrangeDOF_Group
   const ID &theGroupsID = theDofGroup->getID();
   int size3 = theGroupsID.Size();
-  for (int k=0; k<size3; k++) 
+  for (int k=0; k<size3; k++)
     myID(k+size1+size2) = theGroupsID(k);
-  
-  
+
+
   return result;
 }
 
 const Matrix &
 LagrangeMP_FE::getTangent(Integrator *theNewIntegrator)
 {
-  if (theMP->isTimeVarying() == true)
-    this->determineTangent();
+  if (theNewIntegrator != nullptr) {
+    theNewIntegrator->formEleTangent(this);
+    return *sysTang;
+  }
+  return this->getStaticTangent();
+}
 
-  return *tang;
+void
+LagrangeMP_FE::zeroTangent()
+{
+  sysTang->Zero();
+  urLoaded = false;
+}
+
+void
+LagrangeMP_FE::addKtToTang(double fact)
+{
+  // Copy static coupling, then scale lower-left C by integrator fact (c1).
+  // Upper-right C^T stays unscaled. HALL_TANGENT may call addKi after addKt:
+  // the second call only accumulates the lower-left block.
+  if (fact == 0.0)
+    return;
+
+  const Matrix &Ks = this->getStaticTangent();
+  const int nLambda = Ks.noRows() - numU;
+
+  if (!urLoaded) {
+    *sysTang = Ks;
+    if (fact != 1.0) {
+      for (int i = 0; i < nLambda; i++)
+        for (int j = 0; j < numU; j++)
+          (*sysTang)(numU + i, j) *= fact;
+    }
+    urLoaded = true;
+  } else {
+    for (int i = 0; i < nLambda; i++)
+      for (int j = 0; j < numU; j++)
+        (*sysTang)(numU + i, j) += Ks(numU + i, j) * fact;
+  }
+}
+
+void
+LagrangeMP_FE::addKiToTang(double fact)
+{
+  this->addKtToTang(fact);
+}
+
+void
+LagrangeMP_FE::addCtoTang(double fact)
+{
+  // no damping contribution from lagrange constraint
+}
+
+void
+LagrangeMP_FE::addMtoTang(double fact)
+{
+  // no mass contribution from lagrange constraint
 }
 
 const Vector &
 LagrangeMP_FE::getResidual(Integrator *theNewIntegrator)
 {
+  if (theNewIntegrator != nullptr)
+    theNewIntegrator->formEleResidual(this);
+  return *resid;
+}
+
+void
+LagrangeMP_FE::zeroResidual()
+{
+  resid->Zero();
+}
+
+void
+LagrangeMP_FE::addRtoResidual(double fact)
+{
+  if (fact == 0.0)
+    return;
+
   // get the solution vector [Uc Ur lambda]
   static Vector UU;
   const ID& id1 = theMP->getConstrainedDOFs();
@@ -239,7 +320,7 @@ LagrangeMP_FE::getResidual(Integrator *theNewIntegrator)
   for (int i = 0; i < id1.Size(); ++i) {
       int cdof = id1(i);
       if (cdof < 0 || cdof >= Uc.Size()) {
-        opserr << "LagrangeMP_FE::getResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
+        opserr << "LagrangeMP_FE::addRtoResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
         exit(-1);
       }
       UU(i) = Uc(cdof) - Uc0(i);
@@ -247,7 +328,7 @@ LagrangeMP_FE::getResidual(Integrator *theNewIntegrator)
   for (int i = 0; i < id2.Size(); ++i) {
     int rdof = id2(i);
     if (rdof < 0 || rdof >= Ur.Size()) {
-      opserr << "LagrangeMP_FE::getResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
+      opserr << "LagrangeMP_FE::addRtoResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
       exit(-1);
     }
     UU(i + id1.Size()) = Ur(rdof) - Ur0(i);
@@ -268,67 +349,116 @@ LagrangeMP_FE::getResidual(Integrator *theNewIntegrator)
 
   */
 
-  // compute residual
-  const Matrix& KK = getTangent(theNewIntegrator);
-  resid->addMatrixVector(0.0, KK, UU, -1.0);
-
-  // done
-  return *resid;
+  // compute residual from unscaled static coupling (no c1)
+  resid->addMatrixVector(1.0, this->getStaticTangent(), UU, -fact);
 }
 
+void
+LagrangeMP_FE::addRIncInertiaToResidual(double fact)
+{
+  this->addRtoResidual(fact);
+}
 
+void
+LagrangeMP_FE::addM_Force(const Vector &accel, double fact)
+{
+  // no-op
+}
+
+void
+LagrangeMP_FE::addD_Force(const Vector &vel, double fact)
+{
+  // no-op
+}
 
 const Vector &
 LagrangeMP_FE::getTangForce(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getTangForce() - not yet implemented\n";
- return *resid;
-}
+  resid->Zero();
 
+  if (fact == 0.0)
+    return *resid;
+
+  // use last integrator's system tangent (includes c1 on lower-left)
+  const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+  const int size = resid->Size();
+  const int dispSize = disp.Size();
+  Vector tmp(size);
+  for (int i = 0; i < size; i++) {
+    int dof = myID(i);
+    if (dof >= 0 && dof < dispSize)
+      tmp(i) = disp(dof);
+  }
+
+  if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+    opserr << "WARNING LagrangeMP_FE::getTangForce() - ";
+    opserr << "- addMatrixVector returned error\n";
+  }
+
+  return *resid;
+}
 
 const Vector &
 LagrangeMP_FE::getK_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getK_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+
+  if (fact == 0.0)
+    return *resid;
+
+  const int size = resid->Size();
+  const int dispSize = disp.Size();
+  Vector tmp(size);
+  for (int i = 0; i < size; i++) {
+    int dof = myID(i);
+    if (dof >= 0 && dof < dispSize)
+      tmp(i) = disp(dof);
+  }
+
+  if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+    opserr << "WARNING LagrangeMP_FE::getK_Force() - ";
+    opserr << "- addMatrixVector returned error\n";
+  }
+
+  return *resid;
 }
 
 const Vector &
 LagrangeMP_FE::getKi_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING LagrangeMP_FE::getKi_Force() - not yet implemented\n";
- return *resid;
+  return this->getK_Force(disp, fact);
 }
 
 const Vector &
 LagrangeMP_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getC_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+  return *resid;
 }
 
 const Vector &
 LagrangeMP_FE::getM_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING lagrangeMP_FE::getM_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+  return *resid;
 }
 
-void  
+void
 LagrangeMP_FE::determineTangent()
 {
   const Matrix &constraint = theMP->getConstraint();
   const int noRows = constraint.noRows();
   const int noCols = constraint.noCols();
   const int n = noRows+noCols;
-  
-  tang->Zero();    
+
+  tang->Zero();
 
   for (int j=0; j<noRows; j++) {
     (*tang)(n+j, j) = -alpha;
-    (*tang)(j, n+j) = -alpha;        
+    (*tang)(j, n+j) = -alpha;
   }
-  
+
   for (int i=0; i<noRows; i++)
     for (int j=0; j<noCols; j++) {
         double val = constraint(i,j) * alpha;
@@ -336,4 +466,3 @@ LagrangeMP_FE::determineTangent()
         (*tang)(noRows+j, n+i) = val;
     }
 }
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.h
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeMP_FE.h
@@ -19,8 +19,8 @@
 ** ****************************************************************** */
 //
 // File: ~/analysis/fe_ele/lagrange/LagrangeMP_FE.h
-// 
-// Written: fmk 
+//
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
@@ -47,41 +47,60 @@ class MP_Constraint;
 class Node;
 class DOF_Group;
 
-class LagrangeMP_FE: public FE_Element
+class LagrangeMP_FE final : public FE_Element
 {
   public:
-    LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &theMP, 
-		  DOF_Group &theDofGrp, double alpha = 1.0);
-    virtual ~LagrangeMP_FE();    
+    LagrangeMP_FE(int tag, Domain &theDomain, MP_Constraint &theMP,
+                  DOF_Group &theDofGrp, double alpha = 1.0);
+    ~LagrangeMP_FE() override;
 
-    // public methods
-    int  setID(AnalysisModel&) final;
-    const ID &getID() const final {return myID;};
-    const Matrix &getTangent(Integrator *) final;    
-    const Vector &getResidual(Integrator *) final;
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int  setID(AnalysisModel &) final;
+    const ID &getID() const final { return myID; }
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);
+    const Matrix &getTangent(Integrator *) override;
+    const Vector &getResidual(Integrator *) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
 
-    void zeroTangent() final {tang? tang->Zero() : void();};
-    
+    void zeroTangent() override;
+    void addKtToTang(double fact = 1.0) override;
+    void addKiToTang(double fact = 1.0) override;
+    void addCtoTang(double fact = 1.0) override;
+    void addMtoTang(double fact = 1.0) override;
+
+    void zeroResidual() override;
+    void addRtoResidual(double fact = 1.0) override;
+    void addRIncInertiaToResidual(double fact = 1.0) override;
+    void addM_Force(const Vector &accel, double fact = 1.0) override;
+    void addD_Force(const Vector &vel, double fact = 1.0) override;
+
   private:
-    ID myID;
-    double alpha;
     void determineTangent();
-    
+
+    const Matrix &getStaticTangent()
+    {
+      if (timeVarying)
+        this->determineTangent();
+      return *tang;
+    }
+
+    ID myID;
+
     MP_Constraint *theMP;
     Node *theConstrainedNode;
-    Node *theRetainedNode;    
+    Node *theRetainedNode;
 
     DOF_Group *theDofGroup;
-    Matrix *tang;
+    Matrix *tang;     // unscaled static coupling
+    Matrix *sysTang;  // integrator-assembled system tangent
     Vector *resid;
+    const bool timeVarying;
+    bool urLoaded;  // true once upper-right C^T has been copied into sysTang
+    double alpha;
+    int numU;  // number of displacement dofs before lambda block
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.cpp
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.cpp
@@ -17,16 +17,16 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.5 $
 // $Date: 2006-02-08 20:20:00 $
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.cpp,v $
-                                                                        
-// Written: fmk 
+
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
-// Purpose: This file contains the code for iSPlementing the methods
+// Purpose: This file contains the code for implementing the methods
 // of the LagrangeSP_FE class interface.
 //
 // the interface:
@@ -48,38 +48,48 @@
 #include <DOF_Group.h>
 
 LagrangeSP_FE::LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &TheSP,
-			     DOF_Group &theGroup, double Alpha)
+                             DOF_Group &theGroup, double Alpha)
 : FE_Element(tag, 2,2),
   myID(2),
-  alpha(Alpha), tang(0), resid(0), theSP(&TheSP), theDofGroup(&theGroup)
+  alpha(Alpha), tang(nullptr), sysTang(nullptr), resid(nullptr), urLoaded(false),
+  theSP(&TheSP), theNode(nullptr), theDofGroup(&theGroup)
 {
   // create a Matrix and a Vector for the tangent and residual
   tang = new Matrix(2,2);
+  sysTang = new Matrix(2,2);
   resid = new Vector(2);
+  if (tang == nullptr || tang->noCols() == 0 ||
+      sysTang == nullptr || sysTang->noCols() == 0 ||
+      resid == nullptr || resid->Size() == 0) {
+    opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
+    opserr << "- ran out of memory\n";
+    exit(-1);
+  }
 
   // zero the Matrix and Vector
   resid->Zero();
   tang->Zero();
+  sysTang->Zero();
 
-  theNode = theDomain.getNode(theSP->getNodeTag());    
-  if (theNode == 0) {
+  theNode = theDomain.getNode(theSP->getNodeTag());
+  if (theNode == nullptr) {
     opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
     opserr << "- no asscoiated Node\n";
     exit(-1);
   }
 
-  // set the tangent
+  // set the tangent: static coupling on [u, lambda] is [0, alpha; alpha, 0]
   (*tang)(0,1) = alpha;
   (*tang)(1,0) = alpha;
-  
+
   // set the myDOF_Groups tags indicating the attached id's of the
   // DOF_Group objects
   DOF_Group *theNodesDOFs = theNode->getDOF_GroupPtr();
   if (theNodesDOFs == 0) {
     opserr << "WARNING LagrangeSP_FE::LagrangeSP_FE()";
     opserr << " - no DOF_Group with Constrained Node\n";
-    exit(-1);	
-  }    
+    exit(-1);
+  }
 
   myDOF_Groups(0) = theNodesDOFs->getTag();
   myDOF_Groups(1) = theDofGroup->getTag();
@@ -87,14 +97,16 @@ LagrangeSP_FE::LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &TheSP,
 
 LagrangeSP_FE::~LagrangeSP_FE()
 {
-    if (tang != 0)
-	delete tang;
-    if (resid != 0)
-	delete resid;
-}    
+  if (tang != nullptr)
+    delete tang;
+  if (sysTang != nullptr)
+    delete sysTang;
+  if (resid != nullptr)
+    delete resid;
+}
 
 // void setID(int index, int value);
-//	Method to set the correSPonding index of the ID to value.
+//  Method to set the correSPonding index of the ID to value.
 int
 LagrangeSP_FE::setID(AnalysisModel& theModel)
 {
@@ -108,109 +120,217 @@ LagrangeSP_FE::setID(AnalysisModel& theModel)
     opserr << "WARNING LagrangeSP_FE::setID()";
     opserr << " - no DOF_Group with Constrained Node\n";
     return -1;
-  }    
+  }
 
   int restrainedDOF = theSP->getDOF_Number();
   const ID &theNodesID = theNodesDOFs->getID();
-  
+
   if (restrainedDOF < 0 || restrainedDOF >= theNodesID.Size()) {
     opserr << "WARNING LagrangeSP_FE::setID()";
     opserr << " - restrained DOF invalid\n";
     return -2;
-  }    	
-  
+  }
+
   myID(0) = theNodesID(restrainedDOF);
   myID(1) = (theDofGroup->getID())(0);
-  
+
   return result;
 }
 
 const Matrix &
 LagrangeSP_FE::getTangent(Integrator *theIntegrator)
 {
-    return *tang;
+  if (theIntegrator != nullptr) {
+    theIntegrator->formEleTangent(this);
+    return *sysTang;
+  }
+  return this->getStaticTangent();
+}
+
+void
+LagrangeSP_FE::zeroTangent()
+{
+  sysTang->Zero();
+  urLoaded = false;
+}
+
+void
+LagrangeSP_FE::addKtToTang(double fact)
+{
+  // Copy static coupling, then scale lower-left C by integrator fact (c1).
+  // Upper-right C^T stays unscaled. HALL_TANGENT may call addKi after addKt:
+  // the second call only accumulates the lower-left block.
+  if (fact == 0.0)
+    return;
+
+  const Matrix &Ks = this->getStaticTangent();
+
+  if (!urLoaded) {
+    *sysTang = Ks;
+    if (fact != 1.0)
+      (*sysTang)(1, 0) *= fact;
+    urLoaded = true;
+  } else {
+    (*sysTang)(1, 0) += Ks(1, 0) * fact;
+  }
+}
+
+void
+LagrangeSP_FE::addKiToTang(double fact)
+{
+  this->addKtToTang(fact);
+}
+
+void
+LagrangeSP_FE::addCtoTang(double fact)
+{
+  // no damping contribution from lagrange constraint
+}
+
+void
+LagrangeSP_FE::addMtoTang(double fact)
+{
+  // no mass contribution from lagrange constraint
 }
 
 const Vector &
 LagrangeSP_FE::getResidual(Integrator *theNewIntegrator)
 {
-    double constraint = theSP->getValue();
-    double initialValue = theSP->getInitialValue();
-    int constrainedDOF = theSP->getDOF_Number();
-    const Vector &nodeDisp = theNode->getTrialDisp();
-    const Vector& lambda = theDofGroup->getTrialDisp();
-
-    if (constrainedDOF < 0 || constrainedDOF >= nodeDisp.Size()) {
-        opserr << "LagrangeSP_FE::getResidual() -";
-        opserr << " constrained DOF " << constrainedDOF << " outside range\n";
-        resid->Zero();
-        return *resid;
-    }
-    if (lambda.Size() != 1) {
-        opserr << "LagrangeSP_FE::getResidual() -";
-        opserr << " Lambda.Size() = " << lambda.Size() << " != 1\n";
-        resid->Zero();
-        return *resid;
-    }
-    
-    /*
-    R = -C*U + G
-       .R = generalized residual vector
-       .C = constraint matrix
-       .U = generalized solution vector (displacement, lagrange multipliers)
-       .G = imposed displacement values
-    | Ru |    | 0  A | | u |   | 0 |
-    |    | = -|      |*|   | + |   |
-    | Rl |    | A  0 | | l |   | g |
-    */
-    (*resid)(0) = alpha * (-lambda(0));
-    (*resid)(1) = alpha *(constraint - (nodeDisp(constrainedDOF) - initialValue));
-    return *resid;
+  if (theNewIntegrator != nullptr)
+    theNewIntegrator->formEleResidual(this);
+  return *resid;
 }
 
+void
+LagrangeSP_FE::zeroResidual()
+{
+  resid->Zero();
+}
 
+void
+LagrangeSP_FE::addRtoResidual(double fact)
+{
+  if (fact == 0.0)
+    return;
 
+  double constraint = theSP->getValue();
+  double initialValue = theSP->getInitialValue();
+  int constrainedDOF = theSP->getDOF_Number();
+  const Vector &nodeDisp = theNode->getTrialDisp();
+  const Vector &lambda = theDofGroup->getTrialDisp();
+
+  if (constrainedDOF < 0 || constrainedDOF >= nodeDisp.Size()) {
+    opserr << "LagrangeSP_FE::addRtoResidual() -";
+    opserr << " constrained DOF " << constrainedDOF << " outside range\n";
+    return;
+  }
+  if (lambda.Size() != 1) {
+    opserr << "LagrangeSP_FE::addRtoResidual() -";
+    opserr << " lambda.Size() = " << lambda.Size() << " != 1\n";
+    return;
+  }
+
+  /*
+  R = -C*U + G
+     .R = generalized residual vector
+     .C = constraint matrix
+     .U = generalized solution vector (displacement, lagrange multipliers)
+     .G = imposed displacement values
+  | Ru |    | 0  A | | u |   | 0 |
+  |    | = -|      |*|   | + |   |
+  | Rl |    | A  0 | | l |   | g |
+  */
+  (*resid)(0) += fact * alpha * (-lambda(0));
+  (*resid)(1) += fact * alpha * (constraint - (nodeDisp(constrainedDOF) - initialValue));
+}
+
+void
+LagrangeSP_FE::addRIncInertiaToResidual(double fact)
+{
+  this->addRtoResidual(fact);
+}
+
+void
+LagrangeSP_FE::addM_Force(const Vector &accel, double fact)
+{
+  // no-op
+}
+
+void
+LagrangeSP_FE::addD_Force(const Vector &vel, double fact)
+{
+  // no-op
+}
 
 const Vector &
 LagrangeSP_FE::getTangForce(const Vector &disp, double fact)
 {
-  double constraint = theSP->getValue();
-  int constrainedID = myID(1);
-  if (constrainedID < 0 || constrainedID >= disp.Size()) {
-    opserr << "WARNING LagrangeSP_FE::getTangForce() - ";	
-    opserr << " constrained DOF " << constrainedID << " outside disp\n";
-    (*resid)(1) = constraint*alpha;
+  resid->Zero();
+
+  if (fact == 0.0)
     return *resid;
+
+  // use last integrator's system tangent (includes c1 on lower-left)
+  const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+  const int size = resid->Size();
+  const int dispSize = disp.Size();
+  Vector tmp(size);
+  for (int i = 0; i < size; i++) {
+    int dof = myID(i);
+    if (dof >= 0 && dof < dispSize)
+      tmp(i) = disp(dof);
   }
-  (*resid)(1) = disp(constrainedID);
-  return *resid;    
+
+  if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+    opserr << "WARNING LagrangeSP_FE::getTangForce() - ";
+    opserr << "- addMatrixVector returned error\n";
+  }
+
+  return *resid;
 }
 
 const Vector &
 LagrangeSP_FE::getK_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getK_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+
+  if (fact == 0.0)
+    return *resid;
+
+  const int size = resid->Size();
+  const int dispSize = disp.Size();
+  Vector tmp(size);
+  for (int i = 0; i < size; i++) {
+    int dof = myID(i);
+    if (dof >= 0 && dof < dispSize)
+      tmp(i) = disp(dof);
+  }
+
+  if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+    opserr << "WARNING LagrangeSP_FE::getK_Force() - ";
+    opserr << "- addMatrixVector returned error\n";
+  }
+
+  return *resid;
 }
 
 const Vector &
 LagrangeSP_FE::getKi_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getKi_Force() - not yet implemented\n";
- return *resid;
+  return this->getK_Force(disp, fact);
 }
 
 const Vector &
 LagrangeSP_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getC_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+  return *resid;
 }
 
 const Vector &
 LagrangeSP_FE::getM_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltySP_FE::getM_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+  return *resid;
 }
-

--- a/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.h
+++ b/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.h
@@ -17,16 +17,16 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.4 $
 // $Date: 2006-02-08 20:20:00 $
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/lagrange/LagrangeSP_FE.h,v $
-                                                                        
-                                                                        
+
+
 #ifndef LagrangeSP_FE_h
 #define LagrangeSP_FE_h
 
-// Written: fmk 
+// Written: fmk
 // Created: 02/99
 // Revision: A
 //
@@ -49,37 +49,49 @@ class SP_Constraint;
 class Node;
 class DOF_Group;
 
-class LagrangeSP_FE: public FE_Element
+class LagrangeSP_FE final : public FE_Element
 {
   public:
-    LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &theSP, 
-		  DOF_Group &theDofGrp, double alpha = 1.0);
-    virtual ~LagrangeSP_FE();    
+    LagrangeSP_FE(int tag, Domain &theDomain, SP_Constraint &theSP,
+                  DOF_Group &theDofGrp, double alpha = 1.0);
+    ~LagrangeSP_FE() override;
 
-    // public methods
-    int  setID(AnalysisModel& ) final;
-    const ID &getID() const final {return myID;};
-    virtual const Matrix &getTangent(Integrator *);    
-    virtual const Vector &getResidual(Integrator *) final;
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int  setID(AnalysisModel &) final;
+    const ID &getID() const final { return myID; }
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0); 
-    void zeroTangent() final {tang? tang->Zero() : void();}
+    const Matrix &getTangent(Integrator *) override;
+    const Vector &getResidual(Integrator *) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    void zeroTangent() override;
+    void addKtToTang(double fact = 1.0) override;
+    void addKiToTang(double fact = 1.0) override;
+    void addCtoTang(double fact = 1.0) override;
+    void addMtoTang(double fact = 1.0) override;
+
+    void zeroResidual() override;
+    void addRtoResidual(double fact = 1.0) override;
+    void addRIncInertiaToResidual(double fact = 1.0) override;
+    void addM_Force(const Vector &accel, double fact = 1.0) override;
+    void addD_Force(const Vector &vel, double fact = 1.0) override;
+
   private:
+    const Matrix &getStaticTangent() { return *tang; }
+
     ID myID;
     double alpha;
-    Matrix *tang;
+    Matrix *tang;     // unscaled static coupling [0, C^T; C, 0]
+    Matrix *sysTang;  // integrator-assembled system tangent
     Vector *resid;
-    
-    SP_Constraint *theSP;
-    Node *theNode;    
+    bool urLoaded;  // true once upper-right C^T has been copied into sysTang
 
+    SP_Constraint *theSP;
+    Node *theNode;
     DOF_Group *theDofGroup;
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.cpp
+++ b/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.cpp
@@ -17,13 +17,13 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 // $Revision: 1.8 $
 // $Date: 2009-10-13 21:13:01 $
 // $Source: /usr/local/cvs/OpenSees/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.cpp,v $
-                                                                        
-                                                                        
-// Written: fmk 
+
+
+// Written: fmk
 // Created: 11/96
 // Revision: A
 //
@@ -48,162 +48,232 @@
 #include <MP_Constraint.h>
 #include <DOF_Group.h>
 
-PenaltyMP_FE::PenaltyMP_FE(int tag, Domain &theDomain, 
-			   MP_Constraint &TheMP, double Alpha)
+PenaltyMP_FE::PenaltyMP_FE(int tag, Domain &theDomain,
+                           MP_Constraint &TheMP, double Alpha)
 :FE_Element(tag, 2,(TheMP.getConstrainedDOFs()).Size()+
                    (TheMP.getRetainedDOFs()).Size()),
  myID( (TheMP.getConstrainedDOFs()).Size()+
        (TheMP.getRetainedDOFs()).Size()),
- theMP(&TheMP), theConstrainedNode(0) , theRetainedNode(0),
- tang(0), resid(0), C(0), alpha(Alpha)
+ theMP(&TheMP), theConstrainedNode(nullptr) , theRetainedNode(nullptr),
+ tang(nullptr), sysTang(nullptr), resid(nullptr), C(nullptr),
+ timeVarying(TheMP.isTimeVarying()), alpha(Alpha)
 {
-    int size;
-    const ID &id1 = theMP->getConstrainedDOFs();
-    size = id1.Size();
-    const ID &id2 = theMP->getRetainedDOFs();    
-    size += id2.Size();
+  int size;
+  const ID &id1 = theMP->getConstrainedDOFs();
+  size = id1.Size();
+  const ID &id2 = theMP->getRetainedDOFs();
+  size += id2.Size();
 
-    tang = new Matrix(size,size);
-    resid = new Vector(size);
-    C = new Matrix(id1.Size(),size);
-	    
-    theRetainedNode = theDomain.getNode(theMP->getNodeRetained());    
-    theConstrainedNode = theDomain.getNode(theMP->getNodeConstrained());
+  tang = new Matrix(size,size);
+  sysTang = new Matrix(size,size);
+  resid = new Vector(size);
+  C = new Matrix(id1.Size(),size);
 
-    if (theRetainedNode == 0 || theConstrainedNode == 0) {
-        opserr << "FATAL PenaltyMP_FE::PenaltyMP_FE() - Constrained or Retained";
-        opserr << " Node does not exist in Domain\n";
-        opserr << theMP->getNodeRetained() << " " << theMP->getNodeConstrained() << endln;
-        exit(-1);
-    }	
+  if (tang == nullptr || sysTang == nullptr || resid == nullptr || C == nullptr ||
+    tang->noCols() != size || sysTang->noCols() != size ||
+    C->noCols() != size || resid->Size() != size) {
+    opserr << "FATAL PenaltyMP_FE::PenaltyMP_FE() - out of memory\n";
+    exit(-1);
+  }
+
+  theRetainedNode = theDomain.getNode(theMP->getNodeRetained());
+  theConstrainedNode = theDomain.getNode(theMP->getNodeConstrained());
+
+  if (theRetainedNode == nullptr || theConstrainedNode == nullptr) {
+    opserr << "FATAL PenaltyMP_FE::PenaltyMP_FE() - Constrained or Retained";
+    opserr << " Node does not exist in Domain\n";
+    opserr << theMP->getNodeRetained() << " " << theMP->getNodeConstrained() << endln;
+    exit(-1);
+  }
 
 
-    // set up the dof groups tags
-    DOF_Group *dofGrpPtr = 0;
-    dofGrpPtr = theRetainedNode->getDOF_GroupPtr();
-    if (dofGrpPtr != 0) 
-        myDOF_Groups(0) = dofGrpPtr->getTag();	    
-    else 
-        opserr << "WARNING PenaltyMP_FE::PenaltyMP_FE() - node no Group yet?\n"; 
-    dofGrpPtr = theConstrainedNode->getDOF_GroupPtr();
-    if (dofGrpPtr != nullptr) 
-        myDOF_Groups(1) = dofGrpPtr->getTag();	        
-    else
-        opserr << "WARNING PenaltyMP_FE::PenaltyMP_FE() - node no Group yet?\n"; 
-    
+  // set up the dof groups tags
+  DOF_Group *dofGrpPtr = nullptr;
+  dofGrpPtr = theRetainedNode->getDOF_GroupPtr();
+  if (dofGrpPtr != nullptr)
+    myDOF_Groups(0) = dofGrpPtr->getTag();
+  else
+    opserr << "WARNING PenaltyMP_FE::PenaltyMP_FE() - node no Group yet?\n";
+  dofGrpPtr = theConstrainedNode->getDOF_GroupPtr();
+  if (dofGrpPtr != nullptr)
+    myDOF_Groups(1) = dofGrpPtr->getTag();
+  else
+    opserr << "WARNING PenaltyMP_FE::PenaltyMP_FE() - node no Group yet?\n";
 
-    if (theMP->isTimeVarying() == false) {
-        this->determineTangent();
-        // we can free up the space taken by C as it is no longer needed
-        if (C != 0)
-            delete C;
-        C = 0;
-    }
+
+  if (!timeVarying) {
+    this->determineTangent();
+    // we can free up the space taken by C as it is no longer needed
+    if (C != nullptr)
+      delete C;
+    C = nullptr;
+  }
 }
 
 PenaltyMP_FE::~PenaltyMP_FE()
 {
-  if (tang != 0)
-    delete tang;
-  if (resid != 0)
-    delete resid;
-  if (C != 0)
-    delete C;
-}    
+  if (tang != nullptr)
+  delete tang;
+  if (sysTang != nullptr)
+  delete sysTang;
+  if (resid != nullptr)
+  delete resid;
+  if (C != nullptr)
+  delete C;
+}
 
 // void setID(int index, int value);
-//	Method to set the correMPonding index of the ID to value.
+//  Method to set the correMPonding index of the ID to value.
 int
 PenaltyMP_FE::setID(AnalysisModel &)
 {
-    int result = 0;
+  int result = 0;
 
-    // first determine the IDs in myID for those DOFs marked
-    // as constrained DOFs, this is obtained from the DOF_Group
-    // associated with the constrained node
-    DOF_Group *theConstrainedNodesDOFs = theConstrainedNode->getDOF_GroupPtr();
-    if (theConstrainedNodesDOFs == 0) {
-        opserr << "WARNING PenaltyMP_FE::setID(void)";
-        opserr << " - no DOF_Group with Constrained Node\n";
-        return -2;
+  // first determine the IDs in myID for those DOFs marked
+  // as constrained DOFs, this is obtained from the DOF_Group
+  // associated with the constrained node
+  DOF_Group *theConstrainedNodesDOFs = theConstrainedNode->getDOF_GroupPtr();
+  if (theConstrainedNodesDOFs == 0) {
+    opserr << "WARNING PenaltyMP_FE::setID(void)";
+    opserr << " - no DOF_Group with Constrained Node\n";
+    return -2;
+  }
+
+  const ID &constrainedDOFs = theMP->getConstrainedDOFs();
+  const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();
+
+  int size1 = constrainedDOFs.Size();
+  for (int i=0; i<size1; i++) {
+    int constrained = constrainedDOFs(i);
+    if (constrained < 0 ||
+      constrained >= theConstrainedNode->getNumberDOF()) {
+
+      opserr << "WARNING PenaltyMP_FE::setID(void) - unknown DOF ";
+      opserr << constrained << " at Node\n";
+      myID(i) = -1; // modify so nothing will be added to equations
+      result = -3;
     }
-
-    const ID &constrainedDOFs = theMP->getConstrainedDOFs();
-    const ID &theConstrainedNodesID = theConstrainedNodesDOFs->getID();    
-    
-    int size1 = constrainedDOFs.Size();
-    for (int i=0; i<size1; i++) {
-        int constrained = constrainedDOFs(i);
-        if (constrained < 0 || 
-            constrained >= theConstrainedNode->getNumberDOF()) {
-            
-            opserr << "WARNING PenaltyMP_FE::setID(void) - unknown DOF ";
-            opserr << constrained << " at Node\n";
-            myID(i) = -1; // modify so nothing will be added to equations
-            result = -3;
-        }    	
-        else {
-            if (constrained >= theConstrainedNodesID.Size()) {
-                opserr << "WARNING PenaltyMP_FE::setID(void) - ";
-                opserr << " Nodes DOF_Group too small\n";
-                myID(i) = -1; // modify so nothing will be added to equations
-                result = -4;
-            }
-            else
-                myID(i) = theConstrainedNodesID(constrained);
-        }
+    else {
+      if (constrained >= theConstrainedNodesID.Size()) {
+        opserr << "WARNING PenaltyMP_FE::setID(void) - ";
+        opserr << " Nodes DOF_Group too small\n";
+        myID(i) = -1; // modify so nothing will be added to equations
+        result = -4;
+      }
+      else
+        myID(i) = theConstrainedNodesID(constrained);
     }
-    
-    // now determine the IDs for the retained dof's
-    DOF_Group *theRetainedNodesDOFs = theRetainedNode->getDOF_GroupPtr();
-    if (theRetainedNodesDOFs == nullptr) {
-        opserr << "WARNING PenaltyMP_FE::setID(void)";
-        opserr << " - no DOF_Group with Retained Node\n";
-        return -2;
+  }
+
+  // now determine the IDs for the retained dof's
+  DOF_Group *theRetainedNodesDOFs = theRetainedNode->getDOF_GroupPtr();
+  if (theRetainedNodesDOFs == nullptr) {
+    opserr << "WARNING PenaltyMP_FE::setID(void)";
+    opserr << " - no DOF_Group with Retained Node\n";
+    return -2;
+  }
+
+  const ID &RetainedDOFs = theMP->getRetainedDOFs();
+  const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();
+
+  int size2 = RetainedDOFs.Size();
+  for (int j=0; j<size2; j++) {
+    int retained = RetainedDOFs(j);
+    if (retained < 0 || retained >= theRetainedNode->getNumberDOF()) {
+      opserr << "WARNING PenaltyMP_FE::setID(void) - unknown DOF ";
+      opserr << retained << " at Node\n";
+      myID(j+size1) = -1; // modify so nothing will be added
+      result = -3;
     }
-    
-    const ID &RetainedDOFs = theMP->getRetainedDOFs();
-    const ID &theRetainedNodesID = theRetainedNodesDOFs->getID();    
-
-    int size2 = RetainedDOFs.Size();
-    for (int j=0; j<size2; j++) {
-        int retained = RetainedDOFs(j);
-        if (retained < 0 || retained >= theRetainedNode->getNumberDOF()) {
-            opserr << "WARNING PenaltyMP_FE::setID(void) - unknown DOF ";
-            opserr << retained << " at Node\n";
-            myID(j+size1) = -1; // modify so nothing will be added
-            result = -3;
-        }    	
-        else {
-            if (retained >= theRetainedNodesID.Size()) {
-                opserr << "WARNING PenaltyMP_FE::setID(void) - ";
-                opserr << " Nodes DOF_Group too small\n";
-                myID(j+size1) = -1; // modify so nothing will be added 
-                result = -4;
-            }
-            else
-                myID(j+size1) = theRetainedNodesID(retained);
-        }
+    else {
+      if (retained >= theRetainedNodesID.Size()) {
+        opserr << "WARNING PenaltyMP_FE::setID(void) - ";
+        opserr << " Nodes DOF_Group too small\n";
+        myID(j+size1) = -1; // modify so nothing will be added
+        result = -4;
+      }
+      else
+        myID(j+size1) = theRetainedNodesID(retained);
     }
+  }
 
-    myDOF_Groups(0) = theConstrainedNodesDOFs->getTag();
-    myDOF_Groups(1) = theRetainedNodesDOFs->getTag();
+  myDOF_Groups(0) = theConstrainedNodesDOFs->getTag();
+  myDOF_Groups(1) = theRetainedNodesDOFs->getTag();
 
-    return result;
+  return result;
 }
 
 const Matrix &
 PenaltyMP_FE::getTangent(Integrator *theNewIntegrator)
 {
-  if (theMP->isTimeVarying() == true)
-    this->determineTangent();
-  return *tang;
+  if (theNewIntegrator != nullptr)
+    theNewIntegrator->formEleTangent(this);
+  return *sysTang;
 }
+
+
+void
+PenaltyMP_FE::zeroTangent()
+{
+  sysTang->Zero();
+}
+
+
+void
+PenaltyMP_FE::addKtToTang(double fact)
+{
+  // Always accumulate: HALL_TANGENT calls both addKtToTang and
+  // addKiToTang, so fact==1.0 must not replace sysTang.
+  if (fact == 0.0)
+    return;
+
+  const Matrix &Ks = this->getStaticTangent();
+  sysTang->addMatrix(1.0, Ks, fact);
+}
+
+
+void
+PenaltyMP_FE::addKiToTang(double fact)
+{
+  this->addKtToTang(fact);
+}
+
+
+void
+PenaltyMP_FE::addCtoTang(double fact)
+{
+  // no damping contribution from penalty constraint
+}
+
+
+void
+PenaltyMP_FE::addMtoTang(double fact)
+{
+  // no mass contribution from penalty constraint
+}
+
 
 const Vector &
 PenaltyMP_FE::getResidual(Integrator *theNewIntegrator)
 {
-  // zero residual, CD = 0
+  if (theNewIntegrator != nullptr)
+    theNewIntegrator->formEleResidual(this);
+  return *resid;
+}
+
+
+void
+PenaltyMP_FE::zeroResidual()
+{
+  resid->Zero();
+}
+
+
+void
+PenaltyMP_FE::addRtoResidual(double fact)
+{
+  if (fact == 0.0)
+    return;
 
   // get the solution vector [Uc Ur]
   static Vector UU;
@@ -216,68 +286,123 @@ PenaltyMP_FE::getResidual(Integrator *theNewIntegrator)
   const Vector& Uc0 = theMP->getConstrainedDOFsInitialDisplacement();
   const Vector& Ur0 = theMP->getRetainedDOFsInitialDisplacement();
   for (int i = 0; i < id1.Size(); ++i) {
-      int cdof = id1(i);
-      if (cdof < 0 || cdof >= Uc.Size()) {
-          opserr << "PenaltyMP_FE::getResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
-          exit(-1);
-      }
-      UU(i) = Uc(cdof) - Uc0(i);
+    int cdof = id1(i);
+    if (cdof < 0 || cdof >= Uc.Size()) {
+      opserr << "PenaltyMP_FE::addRtoResidual FATAL Error: Constrained DOF " << cdof << " out of bounds [0-" << Uc.Size() << "]\n";
+      exit(-1);
+    }
+    UU(i) = Uc(cdof) - Uc0(i);
   }
   for (int i = 0; i < id2.Size(); ++i) {
-      int rdof = id2(i);
-      if (rdof < 0 || rdof >= Ur.Size()) {
-          opserr << "PenaltyMP_FE::getResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
-          exit(-1);
-      }
-      UU(i+id1.Size()) = Ur(rdof) - Ur0(i);
+    int rdof = id2(i);
+    if (rdof < 0 || rdof >= Ur.Size()) {
+      opserr << "PenaltyMP_FE::addRtoResidual FATAL Error: Retained DOF " << rdof << " out of bounds [0-" << Ur.Size() << "]\n";
+      exit(-1);
+    }
+    UU(i+id1.Size()) = Ur(rdof) - Ur0(i);
   }
 
-  // compute residual
-  const Matrix& KK = getTangent(theNewIntegrator);
-  resid->addMatrixVector(0.0, KK, UU, -1.0);
-
-  // done
-  return *resid;
+  // residual contribution = -R with R = K_static*U, same sign as before
+  resid->addMatrixVector(1.0, this->getStaticTangent(), UU, -fact);
 }
 
+
+void
+PenaltyMP_FE::addRIncInertiaToResidual(double fact)
+{
+  // no mass/damping on the constraint
+  this->addRtoResidual(fact);
+}
+
+
+void
+PenaltyMP_FE::addM_Force(const Vector &accel, double fact)
+{
+  // no-op
+}
+
+
+void
+PenaltyMP_FE::addD_Force(const Vector &vel, double fact)
+{
+  // no-op
+}
 
 
 const Vector &
 PenaltyMP_FE::getTangForce(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyMP_FE::getTangForce() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+
+  if (fact == 0.0)
+    return *resid;
+
+  // use last integrator's system tangent (includes c1)
+  const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+  const int size = resid->Size();
+  const int dispSize = disp.Size();
+  Vector tmp(size);
+  for (int i = 0; i < size; i++) {
+    int dof = myID(i);
+    if (dof >= 0 && dof < dispSize)
+      tmp(i) = disp(dof);
+  }
+
+  if (resid->addMatrixVector(0.0, Kt, tmp, fact) < 0) {
+    opserr << "WARNING PenaltyMP_FE::getTangForce() - ";
+    opserr << "- addMatrixVector returned error\n";
+  }
+
+  return *resid;
 }
 
 const Vector &
 PenaltyMP_FE::getK_Force(const Vector &disp, double fact)
 {
-  opserr << "WARNING PenaltyMP_FE::getK_Force() - not yet implemented\n";
+  resid->Zero();
+
+  if (fact == 0.0)
+    return *resid;
+
+  const int size = resid->Size();
+  const int dispSize = disp.Size();
+  Vector tmp(size);  // Vector(int) zeros on construction
+  for (int i = 0; i < size; i++) {
+    int dof = myID(i);
+    if (dof >= 0 && dof < dispSize)
+      tmp(i) = disp(dof);
+  }
+
+  if (resid->addMatrixVector(0.0, this->getStaticTangent(), tmp, fact) < 0) {
+    opserr << "WARNING PenaltyMP_FE::getK_Force() - ";
+    opserr << "- addMatrixVector returned error\n";
+  }
+
   return *resid;
 }
 
 const Vector &
 PenaltyMP_FE::getKi_Force(const Vector &disp, double fact)
 {
-  opserr << "WARNING PenaltyMP_FE::getK_Force() - not yet implemented\n";
-  return *resid;
+  return this->getK_Force(disp, fact);
 }
 
 const Vector &
 PenaltyMP_FE::getC_Force(const Vector &disp, double fact)
 {
- opserr << "WARNING PenaltyMP_FE::getC_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+  return *resid;
 }
 
 const Vector &
 PenaltyMP_FE::getM_Force(const Vector &disp, double fact)
 {
-  // opserr << "WARNING PenaltyMP_FE::getM_Force() - not yet implemented\n";
- return *resid;
+  resid->Zero();
+  return *resid;
 }
 
-void  
+void
 PenaltyMP_FE::determineTangent()
 {
   // first determine [C] = [-I [Ccr]]
@@ -285,19 +410,15 @@ PenaltyMP_FE::determineTangent()
   const Matrix &constraint = theMP->getConstraint();
   int noRows = constraint.noRows();
   int noCols = constraint.noCols();
-    
+
   for (int j=0; j<noRows; j++)
-    (*C)(j,j) = -1.0;
-    
+  (*C)(j,j) = -1.0;
+
   for (int i=0; i<noRows; i++)
-    for (int j=0; j<noCols; j++)
-        (*C)(i,j+noRows) = constraint(i,j);
+  for (int j=0; j<noCols; j++)
+    (*C)(i,j+noRows) = constraint(i,j);
 
   // now form the tangent: [K] = alpha * [C]^t[C]
-  // *(tang) = (*C)^(*C);
-  // *(tang) *= alpha;
   const Matrix &Cref = *C;
   tang->addMatrixTransposeProduct(0.0, Cref, Cref, alpha);
 }
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.h
+++ b/SRC/analysis/fe_ele/penalty/PenaltyMP_FE.h
@@ -17,11 +17,11 @@
 **   Filip C. Filippou (filippou@ce.berkeley.edu)                     **
 **                                                                    **
 ** ****************************************************************** */
-                                                                        
+
 #ifndef PenaltyMP_FE_h
 #define PenaltyMP_FE_h
 
-// Written: fmk 
+// Written: fmk
 // Created: 11/96
 // Revision: A
 //
@@ -43,40 +43,55 @@ class Domain;
 class MP_Constraint;
 class Node;
 
-class PenaltyMP_FE: public FE_Element
+class PenaltyMP_FE final : public FE_Element
 {
   public:
     PenaltyMP_FE(int tag, Domain &, MP_Constraint &, double alpha);
-    virtual ~PenaltyMP_FE();    
+    ~PenaltyMP_FE() override;
 
-    // public methods
     int  setID(AnalysisModel &) final;
-    const ID &getID() const final {return myID;}
-    virtual const Matrix &getTangent(Integrator *theIntegrator);
-    virtual const Vector &getResidual(Integrator *theIntegrator);
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    const ID &getID() const final { return myID; }
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);
-    void zeroTangent() final {tang? tang->Zero() : void();};
-    
+    const Matrix &getTangent(Integrator *) override;
+    const Vector &getResidual(Integrator *) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    void zeroTangent() override;
+    void addKtToTang(double fact = 1.0) override;
+    void addKiToTang(double fact = 1.0) override;
+    void addCtoTang(double fact = 1.0) override;
+    void addMtoTang(double fact = 1.0) override;
+
+    void zeroResidual() override;
+    void addRtoResidual(double fact = 1.0) override;
+    void addRIncInertiaToResidual(double fact = 1.0) override;
+    void addM_Force(const Vector &accel, double fact = 1.0) override;
+    void addD_Force(const Vector &vel, double fact = 1.0) override;
+
   private:
     void determineTangent();
+    const Matrix &getStaticTangent() {
+      if (timeVarying)
+        this->determineTangent();
+      return *tang;
+    }
+
     ID myID;
-    
+
     MP_Constraint *theMP;
     Node *theConstrainedNode;
-    Node *theRetainedNode;    
+    Node *theRetainedNode;
 
-    Matrix *tang;
+    Matrix *tang;      // unscaled static penalty stiffness
+    Matrix *sysTang;   // integrator-assembled system tangent
     Vector *resid;
     Matrix *C;    // to hold the C matrix
+    const bool timeVarying;
     double alpha;
-  
 };
 
 #endif
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltySP_FE.cpp
+++ b/SRC/analysis/fe_ele/penalty/PenaltySP_FE.cpp
@@ -20,7 +20,7 @@
 //
 // File: ~/analysis/fe_ele/penalty/PenaltySP_FE.C
 //
-// Written: fmk 
+// Written: fmk
 // Created: 11/96
 // Revision: A
 //
@@ -48,7 +48,7 @@
 Matrix PenaltySP_FE::tang(1,1);
 Vector PenaltySP_FE::resid(1);
 
-PenaltySP_FE::PenaltySP_FE(int tag, Domain &theDomain, 
+PenaltySP_FE::PenaltySP_FE(int tag, Domain &theDomain,
                            SP_Constraint &TheSP, double Alpha)
 : FE_Element(tag, 1,1), alpha(Alpha),
   myID(1),
@@ -64,15 +64,15 @@ PenaltySP_FE::PenaltySP_FE(int tag, Domain &theDomain,
 
   // set the DOF_Group tags
   DOF_Group *dofGrpPtr = theNode->getDOF_GroupPtr();
-  if (dofGrpPtr != 0) 
-    myDOF_Groups(0) = dofGrpPtr->getTag();    
+  if (dofGrpPtr != nullptr)
+    myDOF_Groups(0) = dofGrpPtr->getTag();
 }
 
 
 PenaltySP_FE::~PenaltySP_FE()
 {
 
-}    
+}
 
 // void setID(int index, int value);
 //        Method to set the corresponding index of the ID to value.
@@ -86,20 +86,20 @@ PenaltySP_FE::setID(AnalysisModel &)
     return -2;
   }
   myDOF_Groups(0) = theNodesDOFs->getTag();
-  
+
   int restrainedDOF = theSP->getDOF_Number();
   if (restrainedDOF < 0 || restrainedDOF >= theNode->getNumberDOF()) {
     opserr << "WARNING PenaltySP_FE::setID(void) - unknown DOF ";
     opserr << restrainedDOF << " at Node\n";
     return -3;
-  }    
+  }
   const ID &theNodesID = theNodesDOFs->getID();
   if (restrainedDOF >= theNodesID.Size()) {
     opserr << "WARNING PenaltySP_FE::setID(void) - ";
     opserr << " Nodes DOF_Group too small\n";
     return -4;
-  }    
-  
+  }
+
   myID(0) = theNodesID(restrainedDOF);
 
   return 0;
@@ -109,65 +109,157 @@ PenaltySP_FE::setID(AnalysisModel &)
 const Matrix &
 PenaltySP_FE::getTangent(Integrator *theNewIntegrator)
 {
-  tang(0,0) = alpha;
+  if (theNewIntegrator != nullptr)
+    theNewIntegrator->formEleTangent(this);
+
   return tang;
+}
+
+
+void
+PenaltySP_FE::zeroTangent()
+{
+  tang.Zero();
+}
+
+
+void
+PenaltySP_FE::addKtToTang(double fact)
+{
+  if (fact == 0.0)
+    return;
+  tang(0,0) += alpha * fact;
+}
+
+
+void
+PenaltySP_FE::addKiToTang(double fact)
+{
+  this->addKtToTang(fact);
+}
+
+
+void
+PenaltySP_FE::addCtoTang(double fact)
+{
+  // no damping contribution from penalty constraint
+}
+
+
+void
+PenaltySP_FE::addMtoTang(double fact)
+{
+  // no mass contribution from penalty constraint
 }
 
 
 const Vector &
 PenaltySP_FE::getResidual(Integrator *theNewIntegrator)
 {
+  if (theNewIntegrator != nullptr)
+    theNewIntegrator->formEleResidual(this);
+  return resid;
+}
+
+
+void
+PenaltySP_FE::zeroResidual()
+{
+  resid.Zero();
+}
+
+
+void
+PenaltySP_FE::addRtoResidual(double fact)
+{
+  if (fact == 0.0)
+    return;
+
   double constraint = theSP->getValue();
   double initialValue = theSP->getInitialValue();
   int constrainedDOF = theSP->getDOF_Number();
   const Vector &nodeDisp = theNode->getTrialDisp();
 
   if (constrainedDOF < 0 || constrainedDOF >= nodeDisp.Size()) {
-    opserr << "WARNING PenaltySP_FE::getTangForce() - ";
+    opserr << "WARNING PenaltySP_FE::addRtoResidual() - ";
     opserr << " constrained DOF " << constrainedDOF << " outside disp\n";
-    resid(0) = 0;
+    return;
   }
 
-  //    (*resid)(0) = alpha * (constraint - nodeDisp(constrainedDOF));    
-  // is replace with the following to remove possible problems with
-  // subtracting very small numbers
+  // residual contribution = -R with R = alpha*((u-u0) - g), same sign as before
+  resid(0) += fact * alpha * (constraint - (nodeDisp(constrainedDOF) - initialValue));
+}
 
-  resid(0) = alpha * (constraint - (nodeDisp(constrainedDOF) - initialValue));    
 
-  return resid;
+void
+PenaltySP_FE::addRIncInertiaToResidual(double fact)
+{
+  // no mass/damping on the constraint
+  this->addRtoResidual(fact);
+}
+
+
+void
+PenaltySP_FE::addM_Force(const Vector &accel, double fact)
+{
+  // no-op
+}
+
+
+void
+PenaltySP_FE::addD_Force(const Vector &vel, double fact)
+{
+  // no-op
 }
 
 
 const Vector &
 PenaltySP_FE::getTangForce(const Vector &disp, double fact)
 {
-  // double constraint = theSP->getValue();
-  int constrainedID = myID(0);
-  if (constrainedID < 0 || constrainedID >= disp.Size()) {
-      opserr << "WARNING PenaltySP_FE::getTangForce() - ";
-      opserr << " constrained DOF " << constrainedID << " outside disp\n";
-      resid(0) = 0.0;
-      return resid;
-  }
-  resid(0) = alpha * disp(constrainedID);
+  resid.Zero();
 
+  if (fact == 0.0)
+    return resid;
+
+  // use last integrator's system tangent (includes c1)
+  const Matrix &Kt = this->getTangent(this->getLastIntegrator());
+
+  const int constrainedID = myID(0);
+  const int dispSize = disp.Size();
+  if (constrainedID < 0 || constrainedID >= dispSize) {
+    opserr << "WARNING PenaltySP_FE::getTangForce() - ";
+    opserr << " constrained DOF " << constrainedID << " outside disp\n";
+    return resid;
+  }
+
+  resid(0) = Kt(0, 0) * disp(constrainedID) * fact;
   return resid;
 }
 
 const Vector &
 PenaltySP_FE::getK_Force(const Vector &disp, double fact)
 {
-  opserr << "WARNING PenaltySP_FE::getK_Force() - not yet implemented\n";
   resid(0) = 0.0;
+
+  if (fact == 0.0)
+    return resid;
+
+  const int constrainedID = myID(0);
+  const int dispSize = disp.Size();
+  if (constrainedID < 0 || constrainedID >= dispSize) {
+    opserr << "WARNING PenaltySP_FE::getK_Force() - ";
+    opserr << " constrained DOF " << constrainedID << " outside disp\n";
+    return resid;
+  }
+
+  resid(0) = alpha * disp(constrainedID) * fact;
   return resid;
 }
 
 const Vector &
 PenaltySP_FE::getKi_Force(const Vector &disp, double fact)
 {
-  opserr << "WARNING PenaltySP_FE::getKi_Force() - not yet implemented\n";
-  resid(0) = 0.0;
-  return resid;
+  return this->getK_Force(disp, fact);
 }
 
 
@@ -186,7 +278,3 @@ PenaltySP_FE::getM_Force(const Vector &disp, double fact)
   resid(0) = 0.0;
   return resid;
 }
-
-
-
-

--- a/SRC/analysis/fe_ele/penalty/PenaltySP_FE.h
+++ b/SRC/analysis/fe_ele/penalty/PenaltySP_FE.h
@@ -26,7 +26,7 @@
 //
 // What: "@(#) PenaltySP_FE.h, revA"
 //
-// Written: fmk 
+// Written: fmk
 // Created: 11/96
 // Revision: A
 //
@@ -43,24 +43,34 @@ class Domain;
 class SP_Constraint;
 class Node;
 
-class PenaltySP_FE: public FE_Element
+class PenaltySP_FE final : public FE_Element
 {
   public:
-    PenaltySP_FE(int tag, Domain &, SP_Constraint &, double alpha=1.0e8);    
-    virtual ~PenaltySP_FE();    
+    PenaltySP_FE(int tag, Domain &, SP_Constraint &, double alpha=1.0e8);
+    ~PenaltySP_FE() override;
 
-    // public methods
-    int  setID(AnalysisModel& ) final;
-    const ID &getID() const final {return myID;}
-    virtual const Matrix &getTangent(Integrator *theIntegrator);
-    virtual const Vector &getResidual(Integrator *theIntegrator);
-    virtual const Vector &getTangForce(const Vector &x, double fact = 1.0);
+    int  setID(AnalysisModel &) final;
+    const ID &getID() const final { return myID; }
 
-    virtual const Vector &getK_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getKi_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getC_Force(const Vector &x, double fact = 1.0);
-    virtual const Vector &getM_Force(const Vector &x, double fact = 1.0);
-    void zeroTangent() final {tang.Zero();}
+    const Matrix &getTangent(Integrator *) override;
+    const Vector &getResidual(Integrator *) override;
+    const Vector &getTangForce(const Vector &x, double fact = 1.0) override;
+    const Vector &getK_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getKi_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getC_Force(const Vector &x, double fact = 1.0) override;
+    const Vector &getM_Force(const Vector &x, double fact = 1.0) override;
+
+    void zeroTangent() override;
+    void addKtToTang(double fact = 1.0) override;
+    void addKiToTang(double fact = 1.0) override;
+    void addCtoTang(double fact = 1.0) override;
+    void addMtoTang(double fact = 1.0) override;
+
+    void zeroResidual() override;
+    void addRtoResidual(double fact = 1.0) override;
+    void addRIncInertiaToResidual(double fact = 1.0) override;
+    void addM_Force(const Vector &accel, double fact = 1.0) override;
+    void addD_Force(const Vector &vel, double fact = 1.0) override;
 
   private:
     ID myID;
@@ -72,5 +82,3 @@ class PenaltySP_FE: public FE_Element
 };
 
 #endif
-
-


### PR DESCRIPTION
**Issue**

`getTangent` in the Penalty and Lagrange FE elements bypassed the integrator. As a result:

1. Constraint terms could be incorrectly included in matrices intended to contain only mass contributions, such as through the eigenvalue assembly path `formM` → `getTangent` → `addM`, or in certain explicit integrators that assemble only mass on the left-hand side.
2. The assembled tangent could be inconsistent with the residual.

This PR routes the Penalty and Lagrange constraint FE tangents through the integrator and also implements previously missing methods, including `getK_Force` and `getTangForce`.