### PR TITLE
(22 Warnings) Commands to unit test `solve(b,x)`

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -41,6 +41,7 @@ jobs:
         echo "XARA_SRC_WARN_COUNT=$XARA_SRC_WARN_COUNT" >> $GITHUB_ENV
         echo "warnings=$XARA_SRC_WARN_COUNT" >> $GITHUB_OUTPUT 
         echo "::warning::We found $XARA_SRC_WARN_COUNT warnings"
+        cmake --build . --target XaraRT -j3 2>&1
 
 
     - name: Post warning count

--- a/SRC/runtime/commands/analysis/algorithm.cpp
+++ b/SRC/runtime/commands/analysis/algorithm.cpp
@@ -44,6 +44,7 @@
 #include <InitialInterpolatedLineSearch.h>
 #include <RegulaFalsiLineSearch.h>
 #include <SecantLineSearch.h>
+#include <ArmijoLineSearch.h>
 
 // Accelerators
 #include <RaphsonAccelerator.h>
@@ -139,7 +140,7 @@ XaraCmd_algorithm(ClientData clientData,
 
 
 EquiSolnAlgo *
-G3Parse_newEquiSolnAlgo(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc,
+G3Parse_newEquiSolnAlgo(ClientData clientData, Tcl_Interp *interp, ArgSize argc,
                         TCL_Char ** const argv)
 {
 
@@ -175,7 +176,7 @@ G3Parse_newEquiSolnAlgo(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc
 
 
 static int
-XaraCmd_algorithm_Linear(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc,
+XaraCmd_algorithm_Linear(ClientData clientData, Tcl_Interp *interp, ArgSize argc,
                            TCL_Char ** const argv)
 {
   BasicAnalysisBuilder *builder = (BasicAnalysisBuilder *)clientData;
@@ -279,7 +280,7 @@ XaraCmd_algorithm_Newton(ClientData clientData,
 
 
 int
-TclCommand_newNewtonHallM(ClientData clientData, Tcl_Interp* interp, Tcl_Size argc, TCL_Char**const argv)
+TclCommand_newNewtonHallM(ClientData clientData, Tcl_Interp* interp, ArgSize argc, TCL_Char**const argv)
 {
   BasicAnalysisBuilder *builder = (BasicAnalysisBuilder *)clientData;
   assert(builder != nullptr);
@@ -341,7 +342,7 @@ TclCommand_newNewtonHallM(ClientData clientData, Tcl_Interp* interp, Tcl_Size ar
 
 
 static EquiSolnAlgo *
-G3_newBFGS(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Char ** const argv)
+G3_newBFGS(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
 {
   assert(clientData != nullptr);
 
@@ -378,6 +379,7 @@ G3_newBFGS(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Char **
   return theNewAlgo;
 }
 
+
 static int
 XaraCmd_algorithm_NewtonLineSearch(ClientData clientData, 
                                    Tcl_Interp *interp, 
@@ -395,29 +397,69 @@ XaraCmd_algorithm_NewtonLineSearch(ClientData clientData,
     MaxEta,
     MinEta,
     PFlag,
-    TypeSearch
+    TypeSearch,
+    PredictionTangent,
+    CorrectionTangent
   };
 
   enum class LineSearchType: int {
-    InitialInterpolated,
-    Bisection,
-    Secant,
-    RegulaFalsi
+    InitialInterpolated=0,
+    Bisection=1,
+    Secant=2,
+    RegulaFalsi=3,
+    Armijo=4
   };
 
   ArgumentTracker<Positions> tracker;
   std::set<int> positions;
 
-  // set some default variable
+  // set default variable
   double tol = 0.8;
   int maxIter = 10;
   double maxEta = 10.0;
   double minEta = 0.1;
   int pFlag = 1;
-  int typeSearch = 0;
+  LineSearchType typeSearch = LineSearchType::InitialInterpolated;
+
+  IncrementalIntegrator::TangentFlagType 
+    correction_tangent = CURRENT_TANGENT,
+    prediction_tangent = CURRENT_TANGENT;
 
   for (int i=2; i<argc; i++) {
-    if (strcmp(argv[i], "-tol") == 0) {
+
+    // Tangent Type
+    if (strcmp(argv[i],"-prediction-tangent")==0 || 
+        strcmp(argv[i],"-correction-tangent")==0) {
+      IncrementalIntegrator::TangentFlagType flag = CURRENT_TANGENT;
+      if (++i >= argc) {
+        opserr << OpenSees::PromptValueError 
+               << "Flag -prediction-tangent requires follow up argument\n";
+        return TCL_ERROR;
+      }
+      if (strcmp(argv[i],"current")==0)
+        flag = CURRENT_TANGENT;
+      else if (strcmp(argv[i],"initial")==0)
+        flag = INITIAL_TANGENT;
+      else if (strcmp(argv[i-1],"-correction-tangent")==0 && strcmp(argv[i], "predictor")==0)
+        flag = PREDICTOR_TANGENT;
+      else {
+        opserr << OpenSees::PromptValueError 
+               << "Invalid value for " << argv[i-1] << ": " << argv[i] << "\n";
+        return TCL_ERROR;
+      }
+
+      if (strcmp(argv[i-1],"-prediction-tangent")==0) {
+        prediction_tangent = flag;
+        tracker.consume(Positions::PredictionTangent);
+      } else {
+        correction_tangent = flag;
+        tracker.consume(Positions::CorrectionTangent);
+      }
+    }
+    //
+    //
+    //
+    else if (strcmp(argv[i], "-tol") == 0) {
       if (++i >= argc) {
         opserr << OpenSees::PromptValueError 
                << "Flag -tol requires follow up argument\n";
@@ -490,15 +532,18 @@ XaraCmd_algorithm_NewtonLineSearch(ClientData clientData,
                << "Flag -type requires follow up argument\n";
         return TCL_ERROR;
       }
+
       if (strcmp(argv[i], "Bisection") == 0) {
-        typeSearch = 1;
+        typeSearch = LineSearchType::Bisection;
       } else if (strcmp(argv[i], "Secant") == 0) {
-        typeSearch = 2;
+        typeSearch = LineSearchType::Secant;
       } else if (strcmp(argv[i], "RegulaFalsi") == 0 ||
                  strcmp(argv[i], "LinearInterpolated") == 0) {
-        typeSearch = 3;
+        typeSearch = LineSearchType::RegulaFalsi;
       } else if (strcmp(argv[i], "InitialInterpolated") == 0) {
-        typeSearch = 0;
+        typeSearch = LineSearchType::InitialInterpolated;
+      } else if (strcmp(argv[i], "Armijo") == 0) {
+        typeSearch = LineSearchType::Armijo;
       } else {
         opserr << OpenSees::PromptValueError 
                << "Unknown line search type: " << argv[i] << "\n";
@@ -564,17 +609,23 @@ XaraCmd_algorithm_NewtonLineSearch(ClientData clientData,
   }
 
   LineSearch *theLineSearch = nullptr;
-  if (typeSearch == 0)
+  if (typeSearch == LineSearchType::InitialInterpolated)
     theLineSearch = new InitialInterpolatedLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-  else if (typeSearch == 1)
+  else if (typeSearch == LineSearchType::Bisection)
     theLineSearch = new BisectionLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-  else if (typeSearch == 2)
+  else if (typeSearch == LineSearchType::Secant)
     theLineSearch = new SecantLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-  else if (typeSearch == 3)
+  else if (typeSearch == LineSearchType::RegulaFalsi)
     theLineSearch = new RegulaFalsiLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-
-
+  else if (typeSearch == LineSearchType::Armijo)
+    theLineSearch = new ArmijoLineSearch(tol, maxIter, minEta, maxEta, pFlag);
+#if 0
+  builder->set(new NewtonLineSearch(theLineSearch,
+                                    prediction_tangent,
+                                    correction_tangent));
+#else
   builder->set(new NewtonLineSearch(theLineSearch));
+#endif
   return TCL_OK;
 }
 
@@ -732,7 +783,7 @@ XaraCmd_algorithm_AcceleratedNewton(ClientData clientData,
 
 
 static EquiSolnAlgo *
-G3_newBroyden(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc,
+G3_newBroyden(ClientData clientData, Tcl_Interp *interp, ArgSize argc,
               TCL_Char ** const argv)
 {
 
@@ -796,24 +847,9 @@ printAlgorithm(ClientData clientData,
   return TCL_OK;
 }
 
-int
-TclCommand_accelCPU(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Char ** const argv)
-{
-  assert(clientData != nullptr);
-  BasicAnalysisBuilder *builder = (BasicAnalysisBuilder *)clientData;
-  const EquiSolnAlgo* algo = builder->getAlgorithm();
-
-  if (algo == nullptr)
-    return TCL_ERROR;
-
-  Tcl_SetObjResult(interp, Tcl_NewDoubleObj(algo->getAccelTimeCPU()));
-
-  return TCL_OK;
-}
-
 
 int
-TclCommand_numFact(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Char ** const argv)
+XaraCmd_numFact(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
 {
   assert(clientData != nullptr);
   BasicAnalysisBuilder *builder = (BasicAnalysisBuilder *)clientData;
@@ -828,7 +864,7 @@ TclCommand_numFact(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL
 }
 
 int
-TclCommand_algorithmRecorder(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc,
+XaraCmd_algorithmRecorder(ClientData clientData, Tcl_Interp *interp, ArgSize argc,
                         TCL_Char ** const argv)
 {
 #if 1
@@ -863,38 +899,10 @@ TclCommand_algorithmRecorder(ClientData clientData, Tcl_Interp *interp, Tcl_Size
 #endif
 }
 
-int
-TclCommand_totalCPU(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Char ** const argv)
-{
-  assert(clientData != nullptr);
-  const EquiSolnAlgo *algo = ((BasicAnalysisBuilder *)clientData)->getAlgorithm();
-
-  if (algo == nullptr)
-    return TCL_ERROR;
-
-  Tcl_SetObjResult(interp, Tcl_NewDoubleObj(algo->getTotalTimeCPU()));
-
-  return TCL_OK;
-}
-
-int
-TclCommand_solveCPU(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Char ** const argv)
-{
-  assert(clientData != nullptr);
-  const EquiSolnAlgo *algo = ((BasicAnalysisBuilder *)clientData)->getAlgorithm();
-
-
-  if (algo == nullptr)
-    return TCL_ERROR;
-
-  Tcl_SetObjResult(interp, Tcl_NewDoubleObj(algo->getSolveTimeCPU()));
-
-  return TCL_OK;
-}
 
 
 int
-XaraCmd_numIter(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Char ** const argv)
+XaraCmd_numIter(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
 {
   assert(clientData != nullptr);
   const EquiSolnAlgo *algo = ((BasicAnalysisBuilder *)clientData)->getAlgorithm();
@@ -907,3 +915,24 @@ XaraCmd_numIter(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, TCL_Ch
   return TCL_OK;
 }
 
+
+int
+XaraCmd_accelCPU(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
+{
+  Tcl_SetObjResult(interp, Tcl_NewDoubleObj(0.0));
+  return TCL_OK;
+}
+
+int
+XaraCmd_totalCPU(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
+{
+  Tcl_SetObjResult(interp, Tcl_NewDoubleObj(0.0));
+  return TCL_OK;
+}
+
+int
+XaraCmd_solveCPU(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
+{
+  Tcl_SetObjResult(interp, Tcl_NewDoubleObj(0.0));
+  return TCL_OK;
+}

--- a/SRC/runtime/commands/analysis/algorithm.cpp
+++ b/SRC/runtime/commands/analysis/algorithm.cpp
@@ -44,8 +44,10 @@
 #include <InitialInterpolatedLineSearch.h>
 #include <RegulaFalsiLineSearch.h>
 #include <SecantLineSearch.h>
+// #define ARMIJO_SEARCH
+#ifdef ARMIJO_SEARCH
 #include <ArmijoLineSearch.h>
-
+#endif
 // Accelerators
 #include <RaphsonAccelerator.h>
 #include <PeriodicAccelerator.h>
@@ -542,8 +544,10 @@ XaraCmd_algorithm_NewtonLineSearch(ClientData clientData,
         typeSearch = LineSearchType::RegulaFalsi;
       } else if (strcmp(argv[i], "InitialInterpolated") == 0) {
         typeSearch = LineSearchType::InitialInterpolated;
+#ifdef ARMIJO_SEARCH
       } else if (strcmp(argv[i], "Armijo") == 0) {
         typeSearch = LineSearchType::Armijo;
+#endif
       } else {
         opserr << OpenSees::PromptValueError 
                << "Unknown line search type: " << argv[i] << "\n";
@@ -617,9 +621,12 @@ XaraCmd_algorithm_NewtonLineSearch(ClientData clientData,
     theLineSearch = new SecantLineSearch(tol, maxIter, minEta, maxEta, pFlag);
   else if (typeSearch == LineSearchType::RegulaFalsi)
     theLineSearch = new RegulaFalsiLineSearch(tol, maxIter, minEta, maxEta, pFlag);
+#ifdef ARMIJO_SEARCH
   else if (typeSearch == LineSearchType::Armijo)
     theLineSearch = new ArmijoLineSearch(tol, maxIter, minEta, maxEta, pFlag);
-#if 0
+#endif
+
+#ifdef ARMIJO_SEARCH
   builder->set(new NewtonLineSearch(theLineSearch,
                                     prediction_tangent,
                                     correction_tangent));
@@ -862,6 +869,7 @@ XaraCmd_numFact(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Cha
 
   return TCL_OK;
 }
+
 
 int
 XaraCmd_algorithmRecorder(ClientData clientData, Tcl_Interp *interp, ArgSize argc,

--- a/SRC/runtime/commands/analysis/algorithm.cpp
+++ b/SRC/runtime/commands/analysis/algorithm.cpp
@@ -442,8 +442,10 @@ XaraCmd_algorithm_NewtonLineSearch(ClientData clientData,
         flag = CURRENT_TANGENT;
       else if (strcmp(argv[i],"initial")==0)
         flag = INITIAL_TANGENT;
+#ifdef ARMIJO_SEARCH
       else if (strcmp(argv[i-1],"-correction-tangent")==0 && strcmp(argv[i], "predictor")==0)
         flag = PREDICTOR_TANGENT;
+#endif
       else {
         opserr << OpenSees::PromptValueError 
                << "Invalid value for " << argv[i-1] << ": " << argv[i] << "\n";

--- a/SRC/runtime/commands/analysis/analysis.cpp
+++ b/SRC/runtime/commands/analysis/analysis.cpp
@@ -72,7 +72,7 @@ XaraInit_AnalysisCommands(Tcl_Interp *interp, ModelRegistry& context)
   Tcl_CreateCommand(interp, "numberer",   XaraCmd_numberer, analysis, nullptr);
   Tcl_CreateCommand(interp, "number",     XaraCmd_number, analysis, nullptr);
 
-  Tcl_CreateCommand(interp, "responseSpectrumAnalysis", &OpenSees::responseSpectrumAnalysis, nullptr, nullptr);
+  Tcl_CreateCommand(interp, "responseSpectrumAnalysis", &XaraCmd_responseSpectrumAnalysis, nullptr, nullptr);
 
 
   static int ncmd = sizeof(tcl_analysis_cmds)/sizeof(char_cmd);
@@ -663,9 +663,10 @@ XaraCmd_printA(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char
 
 
   bool ret = false;
-  double m = 0.0, c = 0.0, k = 0.0;
+  double m = 0.0, c = 0.0, k = 0.0, ki=0.0;
   bool do_mck = false;
   int currentArg = 1;
+  IncrementalIntegrator::TangentFlagType stiffness_state = CURRENT_TANGENT;
   while (currentArg < argc) {
     if ((strcmp(argv[currentArg], "file") == 0) ||
         (strcmp(argv[currentArg], "-file") == 0)) {
@@ -714,6 +715,14 @@ XaraCmd_printA(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char
       }
       do_mck = true;
     }
+    else if ((strcmp(argv[currentArg], "-ki") == 0)) {
+      currentArg++;
+      if (Tcl_GetDouble(interp, argv[currentArg], &ki) != TCL_OK) {
+        opserr << OpenSees::PromptValueError << "failed to read float following flag -ki\n";
+        return TCL_ERROR;
+      }
+      do_mck = true;
+    }
     currentArg++;
   }
   
@@ -724,21 +733,21 @@ XaraCmd_printA(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char
 
   // construct integrator here so that it is not
   // destructed when the `if` scope ends
-  GimmeMCK integrator(m, c, k, 0.0);
+  GimmeMCK integrator(m, c, k, ki);
   if (do_mck) {
     oldint = builder->getTransientIntegrator();
     builder->set(integrator, false);
-    integrator.formTangent(0);
+    integrator.formTangent(stiffness_state);
     integrator.revertToLastStep();
   }
 
   else if (builder->getStaticIntegrator() != nullptr) {
-    builder->getStaticIntegrator()->formTangent();
+    builder->getStaticIntegrator()->formTangent(stiffness_state);
     builder->getStaticIntegrator()->revertToLastStep();
   }
 
   else if (builder->getTransientIntegrator() != nullptr) {
-    builder->getTransientIntegrator()->formTangent(0);
+    builder->getTransientIntegrator()->formTangent(stiffness_state);
     builder->getTransientIntegrator()->revertToLastStep();
   }
   else {
@@ -801,6 +810,7 @@ XaraCmd_printA(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char
   return res;
 }
 
+
 static int
 XaraCmd_printB(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
 {
@@ -840,16 +850,16 @@ XaraCmd_printB(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char
   LinearSOE  *theSOE = builder->getLinearSOE();
   if (theSOE != nullptr) {
 
-    // TODO
-    builder->formUnbalance();
-
     if (theSOE->getNumEqn() == 0) {
       opserr << OpenSees::PromptValueError 
              << "System of equations is empty\n";
       return TCL_ERROR;
     }
 
-    const Vector &b = theSOE->getB();
+    Vector b(theSOE->getNumEqn());
+    // TODO
+    builder->formUnbalance(b);
+
 
     if (ret) {
       const int size = b.Size();
@@ -866,6 +876,208 @@ XaraCmd_printB(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char
 
   return res;
 }
+
+
+static int
+XaraCmd_applyA(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
+{
+  assert(clientData != nullptr);
+  BasicAnalysisBuilder *builder = (BasicAnalysisBuilder*)clientData;
+
+  int res = 0;
+
+  FileStream outputFile;
+  OPS_Stream *output = &opserr;
+
+  bool ret = true;
+  int currentArg = 1;
+  while (currentArg < argc) {
+    if ((strcmp(argv[currentArg], "file") == 0) ||
+        (strcmp(argv[currentArg], "-file") == 0)) {
+      currentArg++;
+      if (currentArg == argc) {
+        opserr << OpenSees::PromptValueError
+               << "-file missing argument\n";
+        return TCL_ERROR;
+      }
+
+      if (outputFile.setFile(argv[currentArg]) != 0) {
+        opserr << "print <filename> .. - failed to open file: "
+               << argv[currentArg] << "\n";
+        return TCL_ERROR;
+      }
+      output = &outputFile;
+    }
+    else
+      break;
+  }
+
+  // Ensure there is one remaining argument, which is the vector to apply A to
+  if (currentArg >= argc) {
+    opserr << OpenSees::PromptValueError
+           << "applyA requires a vector argument\n";
+    return TCL_ERROR;
+  }
+
+  LinearSOE  *theSOE = builder->getLinearSOE();
+  if (theSOE == nullptr) {
+    opserr << OpenSees::PromptValueError 
+           << "No linear system of equations has been set\n";
+    return TCL_ERROR;
+  }
+  if (theSOE->getNumEqn() == 0) {
+    opserr << OpenSees::PromptValueError 
+            << "System of equations is empty\n";
+    return TCL_ERROR;
+  }
+
+
+  Vector B(theSOE->getNumEqn());
+  Vector X(theSOE->getNumEqn());
+
+  // Split argv[currentArg] into a vector of doubles and store in X
+  int list_argc;
+  TCL_Char **list_argv;
+  if (Tcl_SplitList(interp, argv[currentArg], &list_argc, &list_argv) != TCL_OK) {
+    opserr << OpenSees::PromptValueError
+           << "applyA failed to split vector argument\n";
+    return TCL_ERROR;
+  }
+  for (int i = 0; i < list_argc; ++i) {
+    double val;
+    if (Tcl_GetDouble(interp, list_argv[i], &val) != TCL_OK) {
+      opserr << OpenSees::PromptValueError
+             << "applyA failed to read vector element " << i << "\n";
+      Tcl_Free((char *)list_argv);
+      return TCL_ERROR;
+    }
+    if (i < X.Size())
+      X(i) = val;
+  }
+  Tcl_Free((char *)list_argv);
+
+  if (theSOE->formAp(X, B) < 0) {
+    opserr << OpenSees::PromptValueError
+           << "applyA failed to apply matrix A to vector\n";
+    return TCL_ERROR;
+  }
+
+  if (ret) {
+    const int size = B.Size();
+    Tcl_Obj* list = Tcl_NewListObj(size, nullptr);
+    for (int i = 0; i < size; ++i)
+      Tcl_ListObjAppendElement(interp, list, Tcl_NewDoubleObj(B[i]));
+
+    Tcl_SetObjResult(interp, list);
+  } else {
+    *output << B;
+    outputFile.close();
+  }
+
+  return res;
+}
+
+
+static int
+XaraCmd_solveA(ClientData clientData, Tcl_Interp *interp, ArgSize argc, TCL_Char ** const argv)
+{
+  assert(clientData != nullptr);
+  BasicAnalysisBuilder *builder = (BasicAnalysisBuilder*)clientData;
+
+  int res = 0;
+
+  FileStream outputFile;
+  OPS_Stream *output = &opserr;
+
+  bool ret = true;
+  int currentArg = 1;
+  while (currentArg < argc) {
+    if ((strcmp(argv[currentArg], "file") == 0) ||
+        (strcmp(argv[currentArg], "-file") == 0)) {
+      currentArg++;
+      if (currentArg == argc) {
+        opserr << OpenSees::PromptValueError
+               << "-file missing argument\n";
+        return TCL_ERROR;
+      }
+
+      if (outputFile.setFile(argv[currentArg]) != 0) {
+        opserr << "print <filename> .. - failed to open file: "
+               << argv[currentArg] << "\n";
+        return TCL_ERROR;
+      }
+      output = &outputFile;
+    }
+    else
+      break;
+  }
+
+  // Ensure there is one remaining argument, which is the vector to apply A to
+  if (currentArg >= argc) {
+    opserr << OpenSees::PromptValueError
+           << "applyA requires a vector argument\n";
+    return TCL_ERROR;
+  }
+
+  LinearSOE  *theSOE = builder->getLinearSOE();
+  if (theSOE == nullptr) {
+    opserr << OpenSees::PromptValueError 
+           << "No linear system of equations has been set\n";
+    return TCL_ERROR;
+  }
+  if (theSOE->getNumEqn() == 0) {
+    opserr << OpenSees::PromptValueError 
+            << "System of equations is empty\n";
+    return TCL_ERROR;
+  }
+
+
+  Vector B(theSOE->getNumEqn());
+  Vector X(theSOE->getNumEqn());
+
+  // Split argv[currentArg] into a vector of doubles and store in X
+  int list_argc;
+  TCL_Char **list_argv;
+  if (Tcl_SplitList(interp, argv[currentArg], &list_argc, &list_argv) != TCL_OK) {
+    opserr << OpenSees::PromptValueError
+           << "solveA failed to split vector argument\n";
+    return TCL_ERROR;
+  }
+  for (int i = 0; i < list_argc; ++i) {
+    double val;
+    if (Tcl_GetDouble(interp, list_argv[i], &val) != TCL_OK) {
+      opserr << OpenSees::PromptValueError
+             << "solveA failed to read vector element " << i << "\n";
+      Tcl_Free((char *)list_argv);
+      return TCL_ERROR;
+    }
+    if (i < X.Size())
+      B(i) = val;
+  }
+  Tcl_Free((char *)list_argv);
+
+  // opserr << "Solving Ax = b for x, where b = " << B << "\n";
+  if (theSOE->solve(B, X) < 0) {
+    opserr << OpenSees::PromptValueError
+           << "applyA failed to apply matrix A to vector\n";
+    return TCL_ERROR;
+  }
+
+  if (ret) {
+    const int size = X.Size();
+    Tcl_Obj* list = Tcl_NewListObj(size, nullptr);
+    for (int i = 0; i < size; ++i)
+      Tcl_ListObjAppendElement(interp, list, Tcl_NewDoubleObj(X[i]));
+
+    Tcl_SetObjResult(interp, list);
+  } else {
+    *output << X;
+    outputFile.close();
+  }
+
+  return res;
+}
+
 
 // This is removed from the Tcl_Interp in model.cpp
 extern int
@@ -969,15 +1181,15 @@ XaraCmd_constraints(ClientData clientData,
         verbose = true;
       else if (strcmp(argv[i], "-autoPenalty") == 0) {
         if (user_penalty_done) {
-          opserr << OpenSees::PromptValueError << "cannot use with userPenalty\n";
+          opserr << OpenSees::PromptValueError << "cannot use with userPenalty" << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
         if (argc < i+1) {
-          opserr << OpenSees::PromptValueError << "autoPenalty needs a value\n";
+          opserr << OpenSees::PromptValueError << "autoPenalty needs a value" << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
         if (Tcl_GetDouble(interp, argv[i+1], &auto_penalty_oom) != TCL_OK) {
-          opserr << OpenSees::PromptValueError << "autoPenalty needs a numeric value\n";
+          opserr << OpenSees::PromptValueError << "autoPenalty needs a numeric value" << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
         i++;
@@ -986,15 +1198,15 @@ XaraCmd_constraints(ClientData clientData,
       }
       else if (strcmp(argv[i], "-userPenalty") == 0) {
         if (argc < i+1) {
-          opserr << OpenSees::PromptValueError << "userPenalty needs a value\n";
+          opserr << OpenSees::PromptValueError << "userPenalty needs a value" << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
         if (auto_penalty_done) {
-          opserr << OpenSees::PromptValueError << "cannot use userPenalty with autoPenalty\n";
+          opserr << OpenSees::PromptValueError << "cannot use userPenalty with autoPenalty" << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
         if (Tcl_GetDouble(interp, argv[i+1], &user_penalty) != TCL_OK) {
-          opserr << OpenSees::PromptValueError << "userPenalty needs a numeric value\n";
+          opserr << OpenSees::PromptValueError << "userPenalty needs a numeric value" << OpenSees::SignalMessageEnd;
           return TCL_ERROR;
         }
         i++;
@@ -1002,7 +1214,7 @@ XaraCmd_constraints(ClientData clientData,
         user_penalty_done = true;
       }
       else {
-        opserr << OpenSees::PromptValueError << "unknown option " << argv[i] << "\n";
+        opserr << OpenSees::PromptValueError << "unknown option " << argv[i] << OpenSees::SignalMessageEnd;
         return TCL_ERROR;
       }
     }

--- a/SRC/runtime/commands/analysis/analysis.h
+++ b/SRC/runtime/commands/analysis/analysis.h
@@ -24,6 +24,8 @@ static Tcl_CmdProc XaraCmd_analyze;
 static Tcl_CmdProc XaraCmd_eigen;
 static Tcl_CmdProc XaraCmd_printA;
 static Tcl_CmdProc XaraCmd_printB;
+static Tcl_CmdProc XaraCmd_applyA;
+static Tcl_CmdProc XaraCmd_solveA;
 static Tcl_CmdProc initializeAnalysis;
 static Tcl_CmdProc resetModel;
 static Tcl_CmdProc XaraCmd_constraints;
@@ -33,9 +35,7 @@ Tcl_CmdProc TclCommand_clearAnalysis;
 extern Tcl_CmdProc XaraCmd_numberer;
 extern Tcl_CmdProc XaraCmd_number;
 
-namespace OpenSees {
-Tcl_CmdProc responseSpectrumAnalysis;
-}
+Tcl_CmdProc XaraCmd_responseSpectrumAnalysis;
 
 // commands/analysis/integrator.cpp
 extern Tcl_CmdProc XaraCmd_integrator;
@@ -47,31 +47,35 @@ extern Tcl_CmdProc XaraCmd_systemSize;
 // commands/analysis/algorithm.cpp
 extern Tcl_CmdProc XaraCmd_algorithm;
 extern Tcl_CmdProc XaraCmd_numIter;
-extern Tcl_CmdProc TclCommand_accelCPU;
-extern Tcl_CmdProc TclCommand_totalCPU;
-extern Tcl_CmdProc TclCommand_solveCPU;
+extern Tcl_CmdProc XaraCmd_accelCPU;
+extern Tcl_CmdProc XaraCmd_totalCPU;
+extern Tcl_CmdProc XaraCmd_totalCPU;
 extern Tcl_CmdProc TclCommand_numFact;
 
 // from commands/analysis/ctest.cpp
-extern Tcl_CmdProc specifyCTest;
-extern Tcl_CmdProc getCTestNorms;
-extern Tcl_CmdProc getCTestIter;
+extern Tcl_CmdProc XaraCmd_test;
+extern Tcl_CmdProc XaraCmd_testNorms;
+extern Tcl_CmdProc XaraCmd_testIter;
 extern Tcl_CmdProc TclCommand_algorithmRecorder;
 
 // from commands/analysis/sensitivity.cpp
 extern Tcl_CmdProc TclCommand_sensitivityAlgorithm;
 extern Tcl_CmdProc TclCommand_sensLambda;
 
+Tcl_CmdProc XaraCmd_printEigenMatrices;
+
 struct char_cmd {
   const char* name;
   Tcl_CmdProc*  func;
 } const tcl_analysis_cmds[] =  {
+    {"printEigenMatrices", &XaraCmd_printEigenMatrices},
+
     {"system",              &XaraCmd_system},
     {"systemSize",          &XaraCmd_systemSize},
 
-    {"test",                &specifyCTest},
-    {"testIter",            &getCTestIter},
-    {"testNorms",           &getCTestNorms},
+    {"test",                &XaraCmd_test},
+    {"testIter",            &XaraCmd_testIter},
+    {"testNorms",           &XaraCmd_testNorms},
     {"integrator",          &XaraCmd_integrator},
     {"constraints",         &XaraCmd_constraints},
 
@@ -84,15 +88,19 @@ struct char_cmd {
     {"modalDampingQ",       &XaraCmd_modalDamping},
     {"printA",              &XaraCmd_printA},
     {"printB",              &XaraCmd_printB},
+    // for testing 
+    {"applyA",              &XaraCmd_applyA},
+    {"solveA",              &XaraCmd_solveA},
+
     {"reset",               &resetModel},
 
   // From algorithm.cpp
     {"algorithm",           &XaraCmd_algorithm},
     {"numIter",             &XaraCmd_numIter},
     {"numFact",             &TclCommand_numFact},
-    {"accelCPU",            &TclCommand_accelCPU},
-    {"totalCPU",            &TclCommand_totalCPU},
-    {"solveCPU",            &TclCommand_solveCPU},
+    {"accelCPU",            &XaraCmd_accelCPU},
+    {"totalCPU",            &XaraCmd_totalCPU},
+    {"solveCPU",            &XaraCmd_totalCPU},
   // recorder.cpp
     {"algorithmRecorder",   &TclCommand_algorithmRecorder},
 

--- a/SRC/runtime/commands/analysis/analysis.h
+++ b/SRC/runtime/commands/analysis/analysis.h
@@ -50,13 +50,13 @@ extern Tcl_CmdProc XaraCmd_numIter;
 extern Tcl_CmdProc XaraCmd_accelCPU;
 extern Tcl_CmdProc XaraCmd_totalCPU;
 extern Tcl_CmdProc XaraCmd_totalCPU;
-extern Tcl_CmdProc TclCommand_numFact;
+extern Tcl_CmdProc XaraCmd_numFact;
 
 // from commands/analysis/ctest.cpp
 extern Tcl_CmdProc XaraCmd_test;
 extern Tcl_CmdProc XaraCmd_testNorms;
 extern Tcl_CmdProc XaraCmd_testIter;
-extern Tcl_CmdProc TclCommand_algorithmRecorder;
+extern Tcl_CmdProc XaraCmd_algorithmRecorder;
 
 // from commands/analysis/sensitivity.cpp
 extern Tcl_CmdProc TclCommand_sensitivityAlgorithm;
@@ -97,12 +97,12 @@ struct char_cmd {
   // From algorithm.cpp
     {"algorithm",           &XaraCmd_algorithm},
     {"numIter",             &XaraCmd_numIter},
-    {"numFact",             &TclCommand_numFact},
+    {"numFact",             &XaraCmd_numFact},
     {"accelCPU",            &XaraCmd_accelCPU},
     {"totalCPU",            &XaraCmd_totalCPU},
-    {"solveCPU",            &XaraCmd_totalCPU},
+    {"solveCPU",            &XaraCmd_solveCPU},
   // recorder.cpp
-    {"algorithmRecorder",   &TclCommand_algorithmRecorder},
+    {"algorithmRecorder",   &XaraCmd_algorithmRecorder},
 
   // sensitivity
     {"sensitivityAlgorithm", TclCommand_sensitivityAlgorithm},

--- a/SRC/runtime/commands/analysis/analysis.h
+++ b/SRC/runtime/commands/analysis/analysis.h
@@ -49,7 +49,7 @@ extern Tcl_CmdProc XaraCmd_algorithm;
 extern Tcl_CmdProc XaraCmd_numIter;
 extern Tcl_CmdProc XaraCmd_accelCPU;
 extern Tcl_CmdProc XaraCmd_totalCPU;
-extern Tcl_CmdProc XaraCmd_totalCPU;
+extern Tcl_CmdProc XaraCmd_solveCPU;
 extern Tcl_CmdProc XaraCmd_numFact;
 
 // from commands/analysis/ctest.cpp
@@ -68,7 +68,7 @@ struct char_cmd {
   const char* name;
   Tcl_CmdProc*  func;
 } const tcl_analysis_cmds[] =  {
-    {"printEigenMatrices", &XaraCmd_printEigenMatrices},
+    // {"printEigenMatrices", &XaraCmd_printEigenMatrices},
 
     {"system",              &XaraCmd_system},
     {"systemSize",          &XaraCmd_systemSize},

--- a/SRC/runtime/commands/analysis/ctest.cpp
+++ b/SRC/runtime/commands/analysis/ctest.cpp
@@ -1,9 +1,16 @@
 //===----------------------------------------------------------------------===//
 //
 //                                   xara
+//                              https://xara.so
 //
 //===----------------------------------------------------------------------===//
-//                              https://xara.so
+//
+// Copyright (c) 2025, OpenSees/Xara Developers
+// All rights reserved.  No warranty, explicit or implicit, is provided.
+//
+// This source code is licensed under the BSD 2-Clause License.
+// See LICENSE file or https://opensource.org/licenses/BSD-2-Clause
+//
 //===----------------------------------------------------------------------===//
 //
 // Description: This file implements the selection of a convergence test.
@@ -16,6 +23,7 @@
 #include <string.h>
 
 // Convergence tests
+// #include <GeneralTest.h>
 #include <CTestNormUnbalance.h>
 #include <CTestNormDispIncr.h>
 #include <CTestEnergyIncr.h>
@@ -29,11 +37,11 @@
 
 
 static ConvergenceTest*
-TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Size argc, G3_Char ** const argv);
+TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, ArgSize argc, G3_Char ** const argv);
 
 
 int
-specifyCTest(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, G3_Char ** const argv)
+XaraCmd_test(ClientData clientData, Tcl_Interp *interp, ArgSize argc, G3_Char ** const argv)
 {
   assert(clientData != nullptr);
   ConvergenceTest* theNewTest = TclDispatch_newConvergenceTest(clientData, interp, argc, argv);
@@ -41,20 +49,19 @@ specifyCTest(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, G3_Char *
   if (theNewTest == nullptr) {
     // Parse routine is expected to have reported an error
     return TCL_ERROR;
-
   }
-  else {
-    BasicAnalysisBuilder* builder = (BasicAnalysisBuilder*)clientData;
 
-    assert(builder != nullptr);
+  BasicAnalysisBuilder* builder = (BasicAnalysisBuilder*)clientData;
 
-    builder->set(theNewTest);
-  }
+  assert(builder != nullptr);
+
+  builder->set(theNewTest);
   return TCL_OK;
 }
 
+
 static ConvergenceTest*
-TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Size argc, G3_Char ** const argv)
+TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, ArgSize argc, G3_Char ** const argv)
 {
   // get the tolerence first
   double tol     = 1e-12;
@@ -68,6 +75,7 @@ TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Si
   int numIter  = 10;
   int printIt  =  0;
   int normType =  2;
+  // Maximum number of times error can increase before test fails
   int maxIncr  = -1;
 
   // make sure at least one other argument to contain test type
@@ -227,7 +235,8 @@ TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Si
 
 
   if (numIter == 0) {
-    opserr << OpenSees::PromptValueError << "no numIter specified in test command\n";
+    opserr << OpenSees::PromptValueError 
+           << "no numIter specified in test command\n";
     return nullptr;
   }
 
@@ -240,7 +249,35 @@ TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Si
       opserr << OpenSees::PromptValueError << "no tolerance specified in test command\n";
       return nullptr;
     }
+#if 0
+    numIter++;
+    ConvergenceTest *theTest = nullptr;
+    if ((strcmp(argv[1], "Residual") == 0) || (strcmp(argv[1], "NormUnbalance") == 0))
+      theTest = new CTestNormUnbalance(tol, numIter, ConvergenceTest::Silent, normType,
+                                     maxIncr, maxTol);
 
+    else if ((strcmp(argv[1], "Correction") == 0) || 
+             (strcmp(argv[1], "NormDispIncr") == 0))
+      theTest = new CTestNormDispIncr(tol, numIter, ConvergenceTest::Silent, normType, maxTol);
+
+    else if ((strcmp(argv[1], "EnergyIncr") == 0) || 
+             (strcmp(argv[1], "Energy") == 0))
+      theTest = new CTestEnergyIncr(tol, numIter, ConvergenceTest::Silent, normType, maxTol);
+    
+    else if (strcmp(argv[1], "RelativeNormUnbalance") == 0)
+      theTest = new CTestRelativeNormUnbalance(tol, numIter, ConvergenceTest::Silent, normType);
+
+    else if (strcmp(argv[1], "RelativeNormDispIncr") == 0)
+      theTest = new CTestRelativeNormDispIncr(tol, numIter, ConvergenceTest::Silent, normType);
+
+    else if (strcmp(argv[1], "RelativeEnergyIncr") == 0)
+      theTest = new CTestRelativeEnergyIncr(tol, numIter, ConvergenceTest::Silent, normType);
+
+    //
+    if (theTest != nullptr) {
+      return new GeneralTest(theTest, flag);
+    }
+#else
     if ((strcmp(argv[1], "Residual") == 0) || (strcmp(argv[1], "NormUnbalance") == 0))
       return  new CTestNormUnbalance(tol, numIter, flag, normType,
                                      maxIncr, maxTol);
@@ -251,7 +288,16 @@ TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Si
     else if ((strcmp(argv[1], "EnergyIncr") == 0) || 
              (strcmp(argv[1], "Energy") == 0))
       return new CTestEnergyIncr(tol, numIter, flag, normType, maxTol);
+    
+    else if (strcmp(argv[1], "RelativeNormUnbalance") == 0)
+      return new CTestRelativeNormUnbalance(tol, numIter, flag, normType);
 
+    else if (strcmp(argv[1], "RelativeNormDispIncr") == 0)
+      return new CTestRelativeNormDispIncr(tol, numIter, flag, normType);
+
+    else if (strcmp(argv[1], "RelativeEnergyIncr") == 0)
+      return new CTestRelativeEnergyIncr(tol, numIter, flag, normType);
+#endif
 
     else if ((strcmp(argv[1], "Residual&Correction") == 0) || 
              (strcmp(argv[1], "Correction&Residual") == 0) || 
@@ -261,15 +307,6 @@ TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Si
     else if (strcmp(argv[1], "NormDispOrUnbalance") == 0)
       return new NormDispOrUnbalance(tol, tol2, numIter, flag,
                                            normType, maxIncr);
-
-    else if (strcmp(argv[1], "RelativeNormUnbalance") == 0)
-      return new CTestRelativeNormUnbalance(tol, numIter, flag, normType);
-
-    else if (strcmp(argv[1], "RelativeNormDispIncr") == 0)
-      return new CTestRelativeNormDispIncr(tol, numIter, flag, normType);
-
-    else if (strcmp(argv[1], "RelativeEnergyIncr") == 0)
-      return new CTestRelativeEnergyIncr(tol, numIter, flag, normType);
 
     else if (strcmp(argv[1], "RelativeTotalNormDispIncr") == 0)
       return new CTestRelativeTotalNormDispIncr(tol, numIter, flag, normType);
@@ -283,10 +320,11 @@ TclDispatch_newConvergenceTest(ClientData clientData, Tcl_Interp* interp, Tcl_Si
   return nullptr;
 }
 
+
 int
-getCTestNorms(ClientData clientData, Tcl_Interp *interp,
-              Tcl_Size argc,
-              G3_Char ** const argv)
+XaraCmd_testNorms(ClientData clientData, Tcl_Interp *interp,
+                  ArgSize argc,
+                  G3_Char ** const argv)
 {
   assert(clientData != nullptr);
   ConvergenceTest *theTest =
@@ -298,7 +336,38 @@ getCTestNorms(ClientData clientData, Tcl_Interp *interp,
     return TCL_ERROR;
   }
 
-  const Vector &data = theTest->getNorms();
+  int type = 0;
+  const Vector* t_data = nullptr;
+#if 0
+  if (argc > 1) {
+    if (strcmp(argv[1], "Residual") == 0)
+      type = GeneralTest::Residual;
+    else if (strcmp(argv[1], "Increment") == 0)
+      type = GeneralTest::Increment;
+    else if (strcmp(argv[1], "Energy") == 0)
+      type = GeneralTest::Energy;
+    else if (strcmp(argv[1], "RelativeResidual") == 0)
+      type = GeneralTest::RelativeResidual;
+    else if (strcmp(argv[1], "RelativeIncrement") == 0)
+      type = GeneralTest::RelativeIncrement;
+    else if (strcmp(argv[1], "RelativeEnergy") == 0)
+      type = GeneralTest::RelativeEnergy;
+    else {
+      opserr << OpenSees::PromptValueError
+             << "unknown norm type: "
+             << argv[1]
+             << OpenSees::PromptValueError;
+      return TCL_ERROR;
+    }
+    // if (Tcl_GetInt(interp, argv[2], &type) != TCL_OK)
+    //   return TCL_ERROR;
+  }
+
+  if (type != 0) {
+    t_data = theTest->getNorms(type);
+  }
+#endif
+  const Vector &data = t_data ? *t_data : theTest->getNorms();
 
   // int size = data.Size();
   int size = theTest->getNumTests();
@@ -313,7 +382,7 @@ getCTestNorms(ClientData clientData, Tcl_Interp *interp,
 
 
 int
-getCTestIter(ClientData clientData, Tcl_Interp *interp, Tcl_Size argc, G3_Char ** const argv)
+XaraCmd_testIter(ClientData clientData, Tcl_Interp *interp, ArgSize argc, G3_Char ** const argv)
 {
   assert(clientData != nullptr);
   ConvergenceTest *theTest =

--- a/SRC/runtime/commands/analysis/modal/modal.cpp
+++ b/SRC/runtime/commands/analysis/modal/modal.cpp
@@ -6,15 +6,18 @@
 #include "DomainModalProperties.h"
 #include "ResponseSpectrumAnalysis.h"
 
+Tcl_CmdProc XaraCmd_responseSpectrumAnalysis;
+
 namespace OpenSees {
 
-Tcl_CmdProc responseSpectrumAnalysis;
 
 namespace DomainCommands {
 
 int
 modalProperties(ClientData clientData, 
-                Tcl_Interp *interp, Tcl_Size argc, TCL_Char ** const argv)
+                Tcl_Interp *interp,
+                ArgSize argc,
+                TCL_Char ** const argv)
 {
   // modalProperties <-print> <-file $fileName> <-unorm>
 
@@ -24,8 +27,8 @@ modalProperties(ClientData clientData,
   // some kudos
   static bool first_done = false;
   if (!first_done) {
-      opslog << "Using DomainModalProperties - Developed by: Massimo Petracca, Guido Camata, ASDEA Software Technology\n";
-      first_done = true;
+    opslog << "Using DomainModalProperties - Developed by: Massimo Petracca, Guido Camata, ASDEA Software Technology\n";
+    first_done = true;
   }
 
   // init default values
@@ -77,7 +80,7 @@ modalProperties(ClientData clientData,
 
 
   Tcl_CreateCommand(interp, "responseSpectrumAnalysis",
-                    responseSpectrumAnalysis, modal_props, nullptr);
+                    XaraCmd_responseSpectrumAnalysis, modal_props, nullptr);
 
   return TCL_OK;
 }
@@ -85,8 +88,11 @@ modalProperties(ClientData clientData,
 } // namespace DomainCommands
 
 
+} // namespace OpenSees
+
+
 int
-responseSpectrumAnalysis(ClientData clientData, 
+XaraCmd_responseSpectrumAnalysis(ClientData clientData, 
                   Tcl_Interp* interp,
                   Tcl_Size argc, 
                   const char** const argv)
@@ -350,5 +356,3 @@ responseSpectrumAnalysis(ClientData clientData,
   return result == 0? TCL_OK : TCL_ERROR;
 }
 
-
-} // namespace OpenSees

--- a/SRC/runtime/commands/analysis/solver.cpp
+++ b/SRC/runtime/commands/analysis/solver.cpp
@@ -251,7 +251,7 @@ specifySparseGen(G3_Runtime* rt, int argc, G3_Char ** const argv)
     }
 
     else if ((strcmp(argv[count], "npRow")  == 0) ||
-                (strcmp(argv[count], "-npRow") == 0)) {
+             (strcmp(argv[count], "-npRow") == 0)) {
       count++;
       if (count >= argc) {
         opserr << OpenSees::PromptValueError

--- a/SRC/runtime/runtime/BasicAnalysisBuilder.cpp
+++ b/SRC/runtime/runtime/BasicAnalysisBuilder.cpp
@@ -350,6 +350,7 @@ int
 BasicAnalysisBuilder::analyzeStatic(int numSteps, int flag)
 {
   int result = 0;
+  static constexpr int print_flag = 0;
 
   for (int i=0; i<numSteps; i++) {
     // This is done for parallelization
@@ -368,13 +369,11 @@ BasicAnalysisBuilder::analyzeStatic(int numSteps, int flag)
     int stamp = theDomain->hasDomainChanged();
 
     if (stamp != domainStamp) [[unlikely]] {
-      opsdbg << G3_DEBUG_PROMPT 
-             << "Domain changed during static analysis at step " << i+1 << "\n";
+      opsdbg << G3_DEBUG_PROMPT  << "Domain changed during static analysis at step " << i+1 << "\n";
       domainStamp = stamp;
       result = this->domainChanged();
       if (result < 0) {
-        opserr << "domainChanged failed";
-        opserr << " at step " << i << " of " << numSteps << "\n";
+        opserr << "domainChanged failed at step " << i << " of " << numSteps << "\n";
         return -1;
       }
     }
@@ -389,6 +388,7 @@ BasicAnalysisBuilder::analyzeStatic(int numSteps, int flag)
              << " time = " << theDomain->getCurrentTime()
              << "\n";
 
+      // increments time and calls theModel->applyLoadDomain(time)
       result = theStaticIntegrator->newStep();
       if (result < 0) {
         opserr << "The Integrator failed at step: " << i
@@ -400,12 +400,15 @@ BasicAnalysisBuilder::analyzeStatic(int numSteps, int flag)
       }
     }
 
-    if (flag & Iterate) {
-      opsdbg << G3_DEBUG_PROMPT << "Static Analysis: Iterate Step " 
-             << i+1 
-             << " time = " << theDomain->getCurrentTime()
-             << "\n";
 
+    if (print_flag == 1) {
+      opserr << G3_DEBUG_PROMPT << "Step " 
+             << i+1 
+             << ", time = " << theDomain->getCurrentTime()
+             << "\n";
+    }
+
+    if (flag & Iterate) {
       result = theAlgorithm->solveCurrentStep();
       if (result < 0) {
         // Print error message if we have one
@@ -421,7 +424,7 @@ BasicAnalysisBuilder::analyzeStatic(int numSteps, int flag)
     if (theStaticIntegrator->shouldComputeAtEachStep()) {
       result = theStaticIntegrator->computeSensitivities();
       if (result < 0) {
-        opserr << "StaticAnalysis::analyze() - the SensitivityAlgorithm failed";
+        opserr << "SensitivityAlgorithm failed";
         opserr << " at step: " << i << " with domain at load factor ";
         opserr << theDomain->getCurrentTime()
                << OpenSees::SignalMessageEnd;
@@ -1106,14 +1109,23 @@ BasicAnalysisBuilder::getConvergenceTest()
 }
 
 int
-BasicAnalysisBuilder::formUnbalance()
+BasicAnalysisBuilder::formUnbalance(Vector& b)
 {
+#if 0
+  if (theStaticIntegrator != nullptr)
+    return theStaticIntegrator->formUnbalance(b);
+
+  else if (theTransientIntegrator != nullptr)
+    return theTransientIntegrator->formUnbalance(b);
+#else
   if (theStaticIntegrator != nullptr)
     return theStaticIntegrator->formUnbalance();
 
   else if (theTransientIntegrator != nullptr)
     return theTransientIntegrator->formUnbalance();
-
+  
+  b = theSOE->getB();
+#endif
   return -1;
 }
 

--- a/SRC/runtime/runtime/BasicAnalysisBuilder.h
+++ b/SRC/runtime/runtime/BasicAnalysisBuilder.h
@@ -111,7 +111,7 @@ public:
     int  eigen(int numMode, bool generalized, bool findSmallest);
     int  getNumEigen() {return numEigen;}
 
-    int formUnbalance();
+    int formUnbalance(Vector& b);
 
     // Performing analysis
     int analyze(int num_steps, double size_steps, int flag=Increment|Iterate|Commit);

--- a/SRC/system_of_eqn/linearSOE/fullGEN/FullGenLinSOE.h
+++ b/SRC/system_of_eqn/linearSOE/fullGEN/FullGenLinSOE.h
@@ -47,9 +47,9 @@ class FullGenLinSOE : public LinearSOE
     int addB(const Vector &, const ID &, double fact = 1.0);    
     int setB(const Vector &, double fact = 1.0);
     
-    void zeroA();
-    void zeroB();
-    
+    void zeroA() override;
+    void zeroB() override;
+
     int formAp(const Vector &p, Vector &Ap);
 
     const Vector &getX();

--- a/SRC/system_of_eqn/linearSOE/sparseGEN/SuperLU.cpp
+++ b/SRC/system_of_eqn/linearSOE/sparseGEN/SuperLU.cpp
@@ -130,6 +130,66 @@ extern "C" void    dCreate_Dense_Matrix(SuperMatrix *, int, int, double *, int,
 */
 
 int
+SuperLU::setSize()
+{
+  int n = theSOE->size;
+  if (n == 0)
+    return 0;
+
+  else if (n > 0) {
+    // create space for the permutation vectors 
+    // and the elimination tree
+    if (sizePerm < n) {
+
+      if (perm_r != nullptr)
+        delete [] perm_r;
+      perm_r = new (nothrow) int[n];                
+
+      if (perm_c != nullptr)
+        delete [] perm_c;
+      perm_c = new (nothrow) int[n];                
+
+      if (etree != nullptr)
+        delete [] etree;
+      etree = new (nothrow) int[n];                
+
+      sizePerm = n;
+    }
+
+    // initialisation
+    StatInit(&stat);
+
+    // create the SuperMatrix A        
+    dCreate_CompCol_Matrix(&A, n, n, theSOE->nnz, theSOE->A, 
+                            theSOE->rowA, theSOE->colStartA, 
+                            SLU_NC, SLU_D, SLU_GE);
+
+    // obtain and apply column permutation to give SuperMatrix AC
+    get_perm_c(permSpec, &A, perm_c);
+    sp_preorder(&options, &A, perm_c, etree, &AC);
+
+    // // create the rhs SuperMatrix B 
+    // dCreate_Dense_Matrix(&B, n, 1, &theSOE->X[0], n, SLU_DN, SLU_D, SLU_GE);
+      
+    // set the refact variable to 'N' after first factorization with new size 
+    // can set to 'Y'.
+    options.Fact = DOFACT;
+
+    if (symmetric == 'Y')
+      options.SymmetricMode=YES;
+  }
+  else {
+    // opserr << "WARNING SuperLU::setSize()";
+    // opserr << " - order of system <  0\n";
+    return -1;        
+  }
+      
+  return 0;
+}
+
+
+
+int
 SuperLU::solve()
 {
   return this->solve(theSOE->getB(), theSOE->X);
@@ -158,7 +218,11 @@ SuperLU::solve(const Vector& vecB, Vector& vecX)
   const double *Bptr = &vecB(0);
   for (int i=0; i<n; i++)
     *(Xptr++) = *(Bptr++);
+
   Xptr = &vecX(0);
+
+  // create the rhs SuperMatrix B 
+  dCreate_Dense_Matrix(&B, n, 1, &vecX(0), n, SLU_DN, SLU_D, SLU_GE);
 
   GlobalLU_t Glu; /* Not needed on return. */
 
@@ -192,7 +256,7 @@ SuperLU::solve(const Vector& vecB, Vector& vecX)
   // do forward and backward substitution
   trans_t trans = NOTRANS;
   int info;
-  dgstrs (trans, &L, &U, perm_c, perm_r, &B, &stat, &info);    
+  dgstrs(trans, &L, &U, perm_c, perm_r, &B, &stat, &info);    
 
   if (info != 0) {
     // opserr << "WARNING SuperLU::solve(void)- ";
@@ -204,64 +268,5 @@ SuperLU::solve(const Vector& vecB, Vector& vecX)
 }
 
 
-
-
-int
-SuperLU::setSize()
-{
-  int n = theSOE->size;
-  if (n > 0) {
-    // create space for the permutation vectors 
-    // and the elimination tree
-    if (sizePerm < n) {
-
-      if (perm_r != nullptr)
-        delete [] perm_r;
-      perm_r = new (nothrow) int[n];                
-
-      if (perm_c != nullptr)
-        delete [] perm_c;
-      perm_c = new (nothrow) int[n];                
-
-      if (etree != nullptr)
-        delete [] etree;
-      etree = new (nothrow) int[n];                
-
-      sizePerm = n;
-    }
-
-    // initialisation
-    StatInit(&stat);
-
-    // create the SuperMatrix A        
-    dCreate_CompCol_Matrix(&A, n, n, theSOE->nnz, theSOE->A, 
-                            theSOE->rowA, theSOE->colStartA, 
-                            SLU_NC, SLU_D, SLU_GE);
-
-    // obtain and apply column permutation to give SuperMatrix AC
-    get_perm_c(permSpec, &A, perm_c);
-
-    sp_preorder(&options, &A, perm_c, etree, &AC);
-
-    // create the rhs SuperMatrix B 
-    dCreate_Dense_Matrix(&B, n, 1, &theSOE->X[0], n, SLU_DN, SLU_D, SLU_GE);
-      
-    // set the refact variable to 'N' after first factorization with new size 
-    // can set to 'Y'.
-    options.Fact = DOFACT;
-
-    if (symmetric == 'Y')
-      options.SymmetricMode=YES;
-
-  } else if (n == 0)
-    return 0;
-  else {
-    // opserr << "WARNING SuperLU::setSize()";
-    // opserr << " - order of system <  0\n";
-    return -1;        
-  }
-      
-  return 0;
-}
 
 


### PR DESCRIPTION
Implement `solve(b,x)` in more `LinearSOESolver`s and implement `solveA` command for unit testing (https://github.com/simpsoba/benchmarks/pull/3)